### PR TITLE
Fix URL generation for master branch

### DIFF
--- a/src/GitLab.VisualStudio/Services/GitAnalysis.cs
+++ b/src/GitLab.VisualStudio/Services/GitAnalysis.cs
@@ -63,7 +63,7 @@ namespace GitLab.VisualStudio.Services
 
                 case GitLabUrlType.Master:
                 default:
-                    return repository.Head.FriendlyName.Replace("origin/", "");
+                    return "master";
             }
         }
 


### PR DESCRIPTION
When I click `master`, go to `master` instead of the branch `HEAD` is on.