### PR TITLE
Visual Studio 2026 and GitLab 17.x maintained fork updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,20 +42,21 @@ jobs:
         run: |
           $path = "src/GitLab.VisualStudio.UI/Properties/GitApp.cs"
           if (-not (Test-Path $path)) {
-            @'
-namespace GitLab.VisualStudio.UI.Properties
-{
-    // Placeholder generated for CI build validation only.
-    // The real GitApp.cs (which holds the GitLab OAuth application credentials) is
-    // git-ignored and must be supplied locally by developers. The client_id below is
-    // the same public PKCE client id already present in LoginViewModel.cs.
-    internal static class GitApp
-    {
-        public const string client_id = "60e86660b759079b66f429f506166fe1cd8cd5fd350476b06801ea973e46ac93";
-        public const string client_secret = "ci-placeholder-secret";
-    }
-}
-'@ | Out-File -FilePath $path -Encoding utf8
+            $lines = @(
+              'namespace GitLab.VisualStudio.UI.Properties',
+              '{',
+              '    // Placeholder generated for CI build validation only.',
+              '    // The real GitApp.cs (GitLab OAuth credentials) is git-ignored and',
+              '    // must be supplied locally by developers. The client_id below is the',
+              '    // same public PKCE client id already present in LoginViewModel.cs.',
+              '    internal static class GitApp',
+              '    {',
+              '        public const string client_id = "60e86660b759079b66f429f506166fe1cd8cd5fd350476b06801ea973e46ac93";',
+              '        public const string client_secret = "ci-placeholder-secret";',
+              '    }',
+              '}'
+            )
+            Set-Content -Path $path -Value $lines -Encoding utf8
             Write-Host "Created placeholder $path"
           } else {
             Write-Host "$path already exists; leaving it untouched"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build VSIX
+
+on:
+  push:
+    branches:
+      - upgrade/vs2026-support
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
+
+      - name: Locate Visual Studio and inspect Team Explorer assemblies
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsroot = (& $vswhere -latest -property installationPath).Trim()
+          Write-Host "VS install root: $vsroot"
+          "VSINSTALLROOT=$vsroot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+          $te = Join-Path $vsroot "Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer"
+          Write-Host "Team Explorer dir: $te"
+          if (Test-Path $te) {
+            Write-Host "Team Explorer assemblies found:"
+            Get-ChildItem $te -Filter *.dll | Select-Object -ExpandProperty Name | Sort-Object
+          } else {
+            Write-Host "##[warning] Team Explorer directory NOT FOUND on this runner"
+          }
+
+      - name: NuGet restore
+        run: nuget restore GitLabVS.sln
+
+      - name: Build (Release)
+        shell: pwsh
+        run: |
+          msbuild GitLabVS.sln `
+            /p:Configuration=Release `
+            /p:Platform="Any CPU" `
+            /p:DeployExtension=false `
+            /p:VsInstallRoot="$env:VSINSTALLROOT" `
+            /m /v:m
+
+      - name: Upload VSIX artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: GitLab.VisualStudio-vsix
+          path: build/**/*.vsix
+          if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,30 @@ jobs:
             Write-Host "##[warning] Team Explorer directory NOT FOUND on this runner"
           }
 
+      - name: Generate placeholder GitApp.cs (real file is git-ignored)
+        shell: pwsh
+        run: |
+          $path = "src/GitLab.VisualStudio.UI/Properties/GitApp.cs"
+          if (-not (Test-Path $path)) {
+            @'
+namespace GitLab.VisualStudio.UI.Properties
+{
+    // Placeholder generated for CI build validation only.
+    // The real GitApp.cs (which holds the GitLab OAuth application credentials) is
+    // git-ignored and must be supplied locally by developers. The client_id below is
+    // the same public PKCE client id already present in LoginViewModel.cs.
+    internal static class GitApp
+    {
+        public const string client_id = "60e86660b759079b66f429f506166fe1cd8cd5fd350476b06801ea973e46ac93";
+        public const string client_secret = "ci-placeholder-secret";
+    }
+}
+'@ | Out-File -FilePath $path -Encoding utf8
+            Write-Host "Created placeholder $path"
+          } else {
+            Write-Host "$path already exists; leaving it untouched"
+          }
+
       - name: NuGet restore
         run: nuget restore GitLabVS.sln
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ download in the
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery.
 
+## V1.3.1
+
+- Fixed VSIX install failure on Visual Studio 2026 (`InstallByMsiException`): the manifest no longer sets `InstalledByMsi="true"`, so the extension can be installed directly through the Extensions installer / Manage Extensions instead of requiring an MSI.
+
 ## V1.3.0
 
 - Visual Studio 2026 (18.x) support; installs on Visual Studio 2022 and 2026.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ download in the
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery.
 
+## V1.3.0
+
+- Visual Studio 2026 (18.x) support; installs on Visual Studio 2022 and 2026.
+- VSIX install targets updated to `[17.0,19.0)`; architectures switched to amd64 + arm64 (x86 removed).
+- Visual Studio SDK / VSSDK Build Tools upgraded to 17.14; Newtonsoft.Json 13.0.3, Microsoft.Xaml.Behaviors.Wpf 1.1.142, EmbedIO 3.5.2.
+- Team Explorer assemblies resolved from the building VS instance (`$(VsInstallRoot)`) instead of a hard-coded VS2022 path.
+- Fixed Newtonsoft.Json binding redirect (was pointing to 12.0.0.0).
+
 ## V1.0.183
 
  - Fix for " cannot connect to custom gitlab server with different port #50"

--- a/GitLabVS.sln
+++ b/GitLabVS.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32421.90
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.0.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{10559CEB-2FF0-4617-9122-928F7D8D2E3F}"
 	ProjectSection(SolutionItems) = preProject

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatchTag
 mode: ContinuousDeployment
-next-version: 1.0.1
+next-version: 1.3.0
 branches: {}
 ignore:
   sha: []

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,199 @@
+# 交接文档：GitLab.VisualStudio 升级至 VS2026
+
+> 本文档用于把项目当前状态、已做改动、待解决问题完整交接给后续开发者 / AI Agent。
+> 最后更新对应分支：`upgrade/vs2026-support`，最新提交 `b78a3f3`。
+
+---
+
+## 0. TL;DR（一句话现状）
+
+升级目标是让这个 **Visual Studio 的 GitLab 扩展（VSIX）支持 VS2026 + 最新 GitLab**。
+目前：**能编译、能安装到 VS2026**，但**运行时打开"团队资源管理器(Team Explorer)"会抛 MEF 契约不匹配异常**，GitLab 的界面加载不出来。
+根因：扩展用的是**旧版 Team Explorer 扩展模型**，而 CI 是在 **VS2022(17.x)** 上编译的，跑到 **VS2026(18.x)** 上 `ITeamExplorerSection` 契约对不上。
+**下一步**：在装有 VS2026 的机器上**本地编译**（工程已改为按当前 VS 安装目录解析 Team Explorer 程序集），验证 VS2026 是否仍保留该 API；若已删除则需把 UI 迁出 Team Explorer。
+
+---
+
+## 1. 项目概览
+
+- **是什么**：Visual Studio 扩展（VSIX），把 GitLab 集成进 Visual Studio 的 Team Explorer。
+- **技术栈**：C# / **.NET Framework 4.7.2** / WPF / MEF / VS SDK。**仅能在 Windows + Visual Studio + VS SDK 下编译**（Linux/macOS、纯 .NET SDK 都不行）。
+- **仓库**：`Starkxim/GitLab.VisualStudio`
+- **工作分支**：`upgrade/vs2026-support`（PR #2）
+- **原始上游**：`maikebing/GitLab.VisualStudio`
+- **GitLab 访问**：通过 NuGet 包 `NGitLab.Plus 2.0.44`，使用 **REST API v4 + OAuth2/PAT**。
+
+### 解决方案结构（`GitLabVS.sln` 中实际参与构建的 4 个工程）
+
+| 工程 | 作用 |
+|---|---|
+| `src/GitLab.VisualStudio` | **VSIX/Package 主工程**，含 `GitLabPackage.cs`、`source.extension.vsixmanifest`、`WebService.cs`（GitLab API 调用） |
+| `src/GitLab.VisualStudio.Shared` | 共享服务、Models、MEF 接口（`IWebService`、`IStorage` 等） |
+| `src/GitLab.VisualStudio.UI` | WPF 视图/视图模型（登录框、克隆、新建项目、新建 Snippet）；依赖 `EmbedIO`（OAuth 回调用的本地 http server） |
+| `src/GitLab.TeamFoundation.17` | **Team Explorer 集成程序集**。注意：它自己几乎没有源码，而是通过 `<Compile Include="..\GitLab.TeamFoundation.14\...">` **链接引用 `GitLab.TeamFoundation.14` 目录下的 21 个源文件**来编译。 |
+
+### 重要：被链接的源码实际在 `.14` 目录
+
+`GitLab.TeamFoundation.14/15/16` 这几个目录是**历史的按 VS 版本分别编译的工程**（VS2015/2017/2019），**不在解决方案里、不参与构建**。但 `.17` 工程**复用 `.14` 目录里的源文件**。所以：
+- **要改 Team Explorer 的逻辑/界面 → 改 `src/GitLab.TeamFoundation.14/` 下的文件**（它们会被 `.17` 编译进去）。
+- `.14/.15/.16` 工程分别引用仓库里已提交的 `lib/14.0`、`lib/15.0`、`lib/16.0` 中的 Team Explorer DLL；`.17` 工程则引用**当前 VS 安装目录**里的程序集（见下文）。
+
+### UI 全部基于 Team Explorer（关键认知）
+
+扩展**没有独立窗口**，所有界面都挂在 Team Explorer：
+- **连接(Connect)页**：`GitLabConnectSection`（登录入口）
+- **主页(Home)页**：`GitLabHomeSection` + 导航项 `MergeRequests/Issues/Wiki/Graphs/Builds/Pipelines/Snippets`
+- **发布(Sync)页**：`GitLabPublishSection`（发布新仓库到 GitLab）
+- 这些类继承 `TeamExplorerSectionBase` / 实现 `ITeamExplorerSection`、`ITeamExplorerNavigationItem`，通过 `[TeamExplorerSection]` / `[TeamExplorerNavigationItem]` 用 **MEF** 导出。
+- **导航项点击行为 = `OpenInBrowser("merge_requests"/"issues"/...)`**，即**用浏览器打开 GitLab 网页**。扩展**不在 VS 内渲染 MR/Issue 列表**，本质是"快捷入口 + 新建项目/克隆/Snippet/发布"工具。
+
+### 登录方式（`LoginViewModel` / `ConnectSectionViewModel`）
+
+- 字段：**Host**（默认 `https://gitlab.com`）、Email/用户名、Password。
+- 用 **Personal Access Token** 时：勾选 **2FA**，把 token 填进密码框（勾 2FA 时密码框值被当 token）。
+- **API 版本** 默认 `AutoDiscovery`。
+- 代码里有 `gitlab.com/oauth/authorize` 的 OAuth 流程，但**回调换 token 部分是半成品（有 TODO 未完成）**，实际请用 Host + PAT/密码登录。
+
+---
+
+## 2. 本次升级已完成的改动（分支 `upgrade/vs2026-support`）
+
+### 2.1 VSIX 清单 `src/GitLab.VisualStudio/source.extension.vsixmanifest`
+- `InstallationTarget` 版本范围 `[17.0,18.0)` → **`[17.0,19.0)`**（覆盖 VS2026=18.x）。
+- 移除不再支持的 **x86** 目标；保留 **amd64** 并新增 **arm64**。
+- `Dependencies`（MPF.17.0、TeamExplorer.Extensions）与 `Prerequisite`（CoreEditor）上限同步抬到 `19.0`。
+- 版本号 `1.2.202` → `1.3.0` → **`1.3.1`**。
+- **移除 `<Installation InstalledByMsi="true">` 的 `InstalledByMsi` 属性**（这是"安装失败"的根因，见 3.2）。
+
+### 2.2 NuGet 包版本（4 个工程一致）
+| 包 | 旧 | 新 | 备注 |
+|---|---|---|---|
+| Microsoft.VisualStudio.SDK | 17.1.32210.191 | **17.14.40265** | 17.x 向前兼容 VS2026 |
+| Microsoft.VSSDK.BuildTools | 17.1.4057 | **17.14.2142** | |
+| Microsoft.VisualStudio.Shell.Framework | 17.1.32210.191 | **17.14.40264** | ⚠️ `.40265` 在 NuGet 不存在，最高 `.40264`（曾导致 `NU1102`） |
+| Newtonsoft.Json | 13.0.1 | **13.0.3** | |
+| Microsoft.Xaml.Behaviors.Wpf | 1.1.39 | **1.1.142** | |
+| EmbedIO | 3.4.3 | **3.5.2** | 仅 UI 工程 |
+| NGitLab.Plus | 2.0.44 | 2.0.44 | 已是最新，未动 |
+| LibGit2Sharp | 0.26.2 | 0.26.2 | 保守不动，避免原生二进制打包问题 |
+- 同时移除了主工程里过时的 `Microsoft.VSSDK.BuildTools.15.1.192` props 导入。
+
+### 2.3 修复 Newtonsoft.Json 绑定重定向
+`app.config` 里 `newVersion` 原误写为 `12.0.0.0`（包其实是 13.x），已改为 **`13.0.0.0`**（主工程 / UI / TF.17 三处）。
+
+### 2.4 Team Explorer 程序集引用改为版本无关
+`src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj`：原本硬编码 `C:\Program Files\Microsoft Visual Studio\2022\Professional\...\Team Explorer\`，已改为：
+```xml
+<TeamExplorerDir Condition="'$(VsInstallRoot)' != ''">$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</TeamExplorerDir>
+<TeamExplorerDir Condition="'$(TeamExplorerDir)' == '' and '$(DevEnvDir)' != ''">$(DevEnvDir)CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</TeamExplorerDir>
+```
+**含义**：在哪个版本的 VS 里编译，就绑定哪个版本的 Team Explorer 程序集。**这正是本地用 VS2026 编译可能修好运行时报错的关键**（见 3.3）。
+
+### 2.5 其他
+- `src/common/SolutionInfo.cs`：版本 `1.3.0.0`，修正版权字符。
+- `.sln` 头 `Visual Studio Version 18`；`appveyor.yml` 镜像改 `Visual Studio 2022`；`GitVersion.yml` → `1.3.0`。
+- `README.md` / `CHANGELOG.md` 更新；`docs/build.md` 写入完整构建说明。
+
+### 2.6 CI 工作流 `.github/workflows/build.yml`
+- `runs-on: windows-2022`（**GitHub 暂无 VS2026 runner 镜像，所以 CI 实际用 VS2022(17.14) 编译**——这点很重要，是运行时报错的根源之一）。
+- 步骤：`setup-msbuild` → 用 `vswhere` 定位 VS 并探测 Team Explorer 目录 → **生成占位 `GitApp.cs`** → `nuget restore` → `msbuild /p:Configuration=Release /p:VsInstallRoot=...` → 上传 VSIX artifact。
+
+---
+
+## 3. 关键问题与排障历史
+
+### 3.1 [已解决] CI 编译失败 `NU1102`
+`Microsoft.VisualStudio.Shell.Framework` 被钉成 `17.14.40265`（不存在），改为 `17.14.40264`。
+
+### 3.2 [已解决] 安装失败 `InstallByMsiException`
+VSIX 清单含 `InstalledByMsi="true"`，VSIXInstaller 拒绝直接安装（除非由 MSI 提供清单）。已移除该属性。日志确认用户是在 **VS2026 Community（`D:\Program Files\VS18\`）** 上安装——说明 `[17.0,19.0)` 目标被 VS2026 接受。
+
+### 3.3 [⚠️ 当前未解决 / 最重要] 运行时 MEF 契约不匹配
+打开团队资源管理器时报：
+```
+System.ComponentModel.Composition.CompositionContractMismatchException:
+无法将类型 ...MefV1ExportProvider+ComposablePartForExportFactory 的基础导出值
+强制转换为类型 Microsoft.TeamFoundation.Controls.ITeamExplorerSection
+  ... 在 Microsoft.TeamFoundation.Controls.WPF.TeamExplorer.Framework.TeamExplorerSectionHost.Create()
+```
+**根因分析**：
+1. 扩展 UI 全用旧版 Team Explorer 扩展模型（`ITeamExplorerSection` 等，来自 `Microsoft.TeamFoundation.Controls.dll`）。
+2. CI 在 **VS2022(17.x) runner** 上编译 → 产物引用 **v17** 的 `Microsoft.TeamFoundation.Controls`。
+3. 在 **VS2026(18.x)** 运行时，宿主用的是**另一版本**的该程序集 → VS-MEF 把我们的 Section 强转成宿主的 `ITeamExplorerSection` 时类型对不上 → 抛异常 → GitLab 的 Section 加载失败。
+4. 微软"VS2022 扩展直接在 VS2026 可用"只覆盖**受支持的 API**；**Team Explorer 这套老扩展模型不在其列**（VS2022/2026 默认启用"新的 Git 用户体验"，已替换 Team Explorer 的 Git 页）。
+
+---
+
+## 4. 建议的解决路径（按优先级）
+
+### ✅ 路径 A（首选，本地验证）：在 VS2026 上本地编译
+因 2.4 的改动，工程会按**当前 VS**解析 Team Explorer 程序集。在 VS2026 上编译，产物即引用 **18.x**，契约理论上与宿主匹配。
+- **若能编译通过** → 说明 VS2026 仍保留该 API，重编后大概率修好运行时报错。
+- **若编译报"找不到类型/接口"** → 说明 VS2026 删/改了该 API，必须走路径 C（迁移 UI）。
+
+### 🔍 路径 B（免费快速排查，先试）
+1. `工具 → 选项 → 环境 → 预览功能` → 取消勾选 **"新的 Git 用户体验 / New Git user experience"** → 重启 VS（切回经典 Team Explorer）。
+2. 清 MEF 缓存：关 VS，删 `%LocalAppData%\Microsoft\VisualStudio\18.0_<id>\ComponentModelCache`，重启。
+
+### 🛠 路径 C（长久方案，若 API 已不可用）
+把登录 / MR / Issue 等入口从 Team Explorer **迁移到独立的工具窗口（ToolWindowPane）或 VS 新扩展模型**，不再依赖 `ITeamExplorerSection`。这是较大改造，但在 VS2026 上才是可持续的。
+
+### 📦 路径 D（让 CI 也能出 VS2026 包）
+按仓库多版本套路新增 **`GitLab.TeamFoundation.18`** 工程，引用 VS2026 的 Team Explorer 程序集。需把下列 DLL 从 VS2026 安装目录拷到仓库 `lib/18.0`（这样连 VS2022 的 CI runner 也能编译出引用 18.x 的程序集）：
+```
+D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\
+  Microsoft.TeamFoundation.Controls.dll   ← 最关键
+  Microsoft.TeamFoundation.Common.dll  /  .Client.dll
+  Microsoft.TeamFoundation.Git*.dll（Client/Controls/Provider/Git/Contracts）
+  Microsoft.VisualStudio.TeamFoundation.dll（及 InitializationPackage / VersionControl 等）
+```
+
+---
+
+## 5. 如何在本地编译（环境与步骤）
+
+**前置**：Windows + **Visual Studio 2022 或 2026**（任意版本），需勾选工作负载：**"Visual Studio 扩展开发(VSSDK)"**、**.NET Framework 4.7.2 目标包**、**Team Explorer** 组件。
+
+**必须先手动创建一个本地文件**（被 `.gitignore` 忽略，干净检出里没有它，否则编译报 `CS2001: ...Properties\GitApp.cs ... could not be found`）：
+`src/GitLab.VisualStudio.UI/Properties/GitApp.cs`
+```csharp
+namespace GitLab.VisualStudio.UI.Properties
+{
+    internal static class GitApp
+    {
+        public const string client_id = "<你的 GitLab OAuth 应用 id（仅 PKCE 登录用，可填源码里已公开的那个）>";
+        public const string client_secret = "<你的 GitLab OAuth 应用 secret>";
+    }
+}
+```
+> 注：`LoginViewModel.cs` 第 247 行已硬编码了一个公开的 PKCE `client_id`，本地占位可直接用它；CI 工作流也是自动生成这个占位文件来通过编译的。
+
+**编译（VS2026 开发者命令提示符）**：
+```cmd
+nuget restore GitLabVS.sln
+msbuild GitLabVS.sln /p:Configuration=Release
+```
+产物：`build\Release\GitLab.VisualStudio.vsix`（约 24MB）。安装时若提示"未签名扩展"属正常（`SignatureState: Unsigned`，不阻止安装）。
+
+详见 `docs/build.md`。
+
+---
+
+## 6. 关键文件清单（改动 / 重点）
+
+- `src/GitLab.VisualStudio/source.extension.vsixmanifest` — VSIX 清单（目标版本/架构/InstalledByMsi）
+- `src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj` — TE 程序集引用方式（`$(VsInstallRoot)`）、链接 `.14` 源码
+- `src/GitLab.TeamFoundation.14/**` — **Team Explorer 的真实源码**（Section / NavigationItem / ViewModel / View）
+- `src/GitLab.VisualStudio/Services/WebService.cs` — GitLab API 调用（NGitLab）
+- `src/GitLab.VisualStudio.UI/ViewModels/LoginViewModel.cs` — 登录逻辑（含半成品 OAuth）
+- `src/*/app.config` — 绑定重定向
+- `.github/workflows/build.yml` — CI（windows-2022 / 生成 GitApp.cs / 出 VSIX artifact）
+- `docs/build.md`、`CHANGELOG.md`、`README.md`
+
+---
+
+## 7. 重要事实速查
+- VS2026 = **18.x**；用户机器安装路径 **`D:\Program Files\VS18\`**。
+- CI 用 **VS2022(17.14)** 编译（GitHub 暂无 VS2026 runner）→ 这是 3.3 运行时报错的直接来源。
+- 微软 VSIX 兼容模型：17.x SDK 构建的扩展**针对受支持 API**可在 VS2026 运行；Team Explorer 老模型**不在受支持范围**。
+- 上一次 CI 成功构建产物已可安装到 VS2026，仅运行时 Team Explorer 加载失败。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 You can log any of your favorite GitLab servers and start your great job!
 
-The GitLab Extension for Visual Studio provides GitLab integration in Visual Studio 2015/2017.
+The GitLab Extension for Visual Studio provides GitLab integration in Visual Studio 2022 and Visual Studio 2026.
 Most of the extension UI lives in the Team Explorer pane, which is available from the View menu.
 
 Appveyor:[![Build status](https://ci.appveyor.com/api/projects/status/qb510idi1wca2vet/branch/master?svg=true)](https://ci.appveyor.com/project/MaiKeBing/gitlab-visualstudio/branch/master)
@@ -52,6 +52,13 @@ If you create a personal access token (https://yourgitlaburl.com/profile/persona
 
 
 ## What's new ?
+
+**V1.3.0**
+* Visual Studio 2026 (18.x) support — the extension now installs and runs on Visual Studio 2022 and 2026.
+* Updated the VSIX manifest install targets to `[17.0,19.0)` and switched architectures to amd64 + arm64 (dropped the unsupported x86 target).
+* Upgraded the Visual Studio SDK / VSSDK Build Tools to 17.14, and refreshed Newtonsoft.Json, Microsoft.Xaml.Behaviors.Wpf and EmbedIO.
+* Team Explorer assemblies are now resolved from the building Visual Studio instance instead of a hard-coded VS2022 path, so the project builds against any installed edition.
+* Fixed the Newtonsoft.Json binding redirect that incorrectly pointed to 12.0.0.0.
 
 **V1.0.189** 
 * Fix Groups and Subgroups missing in Namespace [#53](https://github.com/maikebing/GitLab.VisualStudio/issues/53)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-version: 1.0.{build}
-image: Visual Studio 2017
+version: 1.3.{build}
+image: Visual Studio 2022
 
 install:
   - ps: (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex

--- a/dd_VSIXInstaller_20260618112825_3394.log
+++ b/dd_VSIXInstaller_20260618112825_3394.log
@@ -1,0 +1,1117 @@
+2026/6/18 11:28:25 - Microsoft VSIX Installer
+2026/6/18 11:28:25 - -------------------------------------------
+2026/6/18 11:28:25 - vsixinstaller.exe version:
+2026/6/18 11:28:25 - 18.7.1212+9d21f5fc76
+2026/6/18 11:28:25 - -------------------------------------------
+2026/6/18 11:28:25 - Command line parameters:
+2026/6/18 11:28:25 - C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VsixInstaller\VSIXInstaller.exe,E:\User\a\Downloads\GitLab.VisualStudio.vsix
+2026/6/18 11:28:25 - -------------------------------------------
+2026/6/18 11:28:25 - Microsoft VSIX Installer
+2026/6/18 11:28:25 - -------------------------------------------
+2026/6/18 11:28:27 - Skipping product Microsoft.VisualStudio.Product.BuildTools (7ab9dc72) since it does not support extensions
+2026/6/18 11:28:27 - Initializing Install...
+2026/6/18 11:28:27 - 正在搜索适用的产品...
+2026/6/18 11:28:28 - 找到的已安装产品 - Visual Studio Community 2026
+2026/6/18 11:28:29 - Failed to get 'IVsAppCommandLine' service
+2026/6/18 11:28:30 - Local compatibility list path: C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\CompatibilityList.xml - Timestamp: 134201764628031807
+2026/6/18 11:28:30 - Installed compatibility list path: D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml - Timestamp: 134255282108646403
+2026/6/18 11:28:30 - Using installed compatibility list file at 'D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml'.
+2026/6/18 11:28:30 - Try downloading compatibility list file.
+2026/6/18 11:28:30 - Visual Studio Version: 18.7.11903.348
+2026/6/18 11:28:30 - Parsing compatibility list file - D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - 5fb7364d-2e8c-44a4-95eb-2a382e30fec9
+Extension Version - (,0.5)
+Extension Action - Disable
+Product Version - [14.0.23000,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - 3a012d4e-6057-4e7c-8123-6d4be1d4723c-RC
+Extension Version - (,1.0)
+Extension Action - Disable
+Product Version - [14.0.22528,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - 3a012d4e-6057-4e7c-8123-6d4be1d4723c
+Extension Version - (,42.42.42.42)
+Extension Action - Disable
+Product Version - (,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - DeploymentProject.14.0.VSIX.42D3833A-56C3-440E-8127-558CCE16AE00
+Extension Version - (,2.6)
+Extension Action - Warning
+Product Version - [14.0.23010,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - 177DDE05-53AD-4611-A5A7-1D52F75AA3F0
+Extension Version - (,2.6)
+Extension Action - Warning
+Product Version - [14.0.23010,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - VSColorThemeEditor.26c6a2c2-1956-480f-845d-c32d9a14e1b4
+Extension Version - (,)
+Extension Action - Warning
+Product Version - [16.0.28608.199,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - GitHub.Copilot
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - VS.GitHub.Copilot
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - VS.GitHub.Copilot.Service
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - NuGetSolver.ecccc3de-a53e-4834-8b5d-7f07b8633436
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - Microsoft.NET.UpgradeAssistant
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - Microsoft.AppCAT
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - Microsoft.GitHub.Copilot.Upgrade.NET
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - AppModernizationForDotNet
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11026.187,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:30 - Found extension in incompatibility list
+Extension ID - TimeStampMargin2022.255e8b14-4a53-4eb7-89a7-7ab741c1f612
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.3.11304.161,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:30 - Using AlwaysInvalidCacheInvalidationHandler for VSIXInstaller host.
+2026/6/18 11:28:30 - User extensions root: C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions
+2026/6/18 11:28:30 - Application extensions root: D:\Program Files\VS18\Common7\IDE\Extensions
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Retaining extension 'BrightXaml.c6b5c335-85e8-4243-bdf1-2b6468178ad1' between cache rebuilds.
+2026/6/18 11:28:31 - Retaining extension 'Microsoft.VisualStudio.Copilot.LogViewerExtension' between cache rebuilds.
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Running extension locator 'PerUserExtensionLocator' because the per-user invalidation handler was invalidated
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Running extension locator 'PerMachineExtensionLocator' because the per-instance invalidation handler was invalidated
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Running extension locator 'PerUserSdkExtensionLocator' because the current cache was invalidated.
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Running extension locator 'PerMachineSdkExtensionLocator' because the current cache was invalidated.
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Running extension locator 'VisualStudioExtensibilityExtensionStartupLocator+PerMachine' because the per-instance invalidation handler was invalidated
+2026/6/18 11:28:31 - Cache invalidated by 'AlwaysInvalidCacheInvalidationHandler'
+2026/6/18 11:28:31 - Running extension locator 'VisualStudioExtensibilityExtensionStartupLocator+PerUser' because the per-user invalidation handler was invalidated
+2026/6/18 11:28:31 - Capping recursion at 5 directories in each extension root 'C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions' due to 'default limit behavior'.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\0swlx05l.c14\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\cbakkjnu.erd\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\dxtmkri0.dbn\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\eb50xzrw.iwf\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\elofcywj.05h\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\f3lrtrok.yvt\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\gyl1g4hr.gxi\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\jqaasudw.4oa\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\kioxa4uw.omw\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\pmzp2d2y.ah1\extension.vsixmanifest.
+2026/6/18 11:28:31 - Compatibility list file in server is same from local path.
+2026/6/18 11:28:31 - File content is not updated or not found while downloading the compatibility list file.
+2026/6/18 11:28:31 - Setting discovered per-user extension 'VisualStudioThemePack.453e3fa1-2e0e-467e-abbd-1d08fe6468d1' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'VisualStudioThemePack.453e3fa1-2e0e-467e-abbd-1d08fe6468d1' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension 'CollapseLevel.Michał Wilski.9739fb10-2beb-4d62-b127-ab7b7646a060' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'CollapseLevel.Michał Wilski.9739fb10-2beb-4d62-b127-ab7b7646a060' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension 'IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension 'GitLineCodeLens.fdc9b9b4-6cd7-4400-ba78-5cebc1a3b8c5' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'GitLineCodeLens.fdc9b9b4-6cd7-4400-ba78-5cebc1a3b8c5' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension 'Winterdom.Viasfora.f7a33795-2b40-4125-856c-89b0bd8cd5ab' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'Winterdom.Viasfora.f7a33795-2b40-4125-856c-89b0bd8cd5ab' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension '465b40b6-311a-4e37-9556-95fced2de9c6' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension '465b40b6-311a-4e37-9556-95fced2de9c6' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension '3a7b4930-a5fb-46ec-a9b8-9610c8f953b8' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension '3a7b4930-a5fb-46ec-a9b8-9610c8f953b8' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension 'BookmarkStudio.7ed28d42-37b3-4773-8a6e-e9ca6403a0fc' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'BookmarkStudio.7ed28d42-37b3-4773-8a6e-e9ca6403a0fc' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension 'SolutionColors.dfa813d0-736b-491d-921a-4a3503d41543' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension 'SolutionColors.dfa813d0-736b-491d-921a-4a3503d41543' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Setting discovered per-user extension '41DB9DFA-9F21-45A4-B111-22FBD1C3AD94' initial state to InitialExtensionState { State = Enabled, Reason = Per-user extension enabled via per-user enabled extensions cache }
+2026/6/18 11:28:31 - Extension '41DB9DFA-9F21-45A4-B111-22FBD1C3AD94' initial state set to 'Enabled' because 'Per-user extension enabled via per-user enabled extensions cache'
+2026/6/18 11:28:31 - Capping recursion at 5 directories in each extension root 'D:\Program Files\VS18\Common7\IDE\Extensions' due to 'default limit behavior'.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\5azeavgy.ezz\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\a13rb3tq.l1x\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\b4uz2h3d.f32\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\dr3j2tgd.xat\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\frxn04uo.emo\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft.Vsix.TemplatesPackage\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\oy0h1gjl.1jk\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\TestPlatform\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\VSSDK\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\wsqu1otf.bfz\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\xemax1np.yb1\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Aspire\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\ClickOnce\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\ConnectedServices\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Cookiecutter\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Copilot\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\DebugAdapterHost\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\DebuggerServices\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\IntelliCode\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\IntelliCode.CSharp\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\LiveShare.VSCore\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\ManagedProjectSystem\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Portable Library Tools\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Publish\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\ResourceExplorer\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\TemplateEngine\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\WCF Connected Service\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Web Tools\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Web Tools JSON\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Web Tools Languages Shared\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Web Tools Shared\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\VSSDK\ProjectSystem\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\CodeSense\Framework\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Graphics\Debugger\Extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Modeling\18.0\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Python\Core\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Python\Profiling\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Unit Test Explorer\TestWIExtension\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\VC\ClassWizard\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\Extensions\Microsoft\Web Tools\Azure\extension.vsixmanifest.
+2026/6/18 11:28:31 - Capping recursion at 5 directories in each extension root 'D:\Program Files\VS18\Common7\IDE\CommonExtensions' due to 'default limit behavior'.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\DataDesign\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\AnalyzeCodeCoverage\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\CallHierarchy\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ClientDiagnostics\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\CMake\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\CodeAnalysis\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\DesignTools\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\EBF\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Editor\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ErrorList\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Extensibility\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ExtensibilityProject\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\FSharp\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\HotReload\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Identity\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\IdentityGS\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Interactive\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\InteractiveWindow\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\LanguageServer\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Markdown\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Microsoft.VisualStudio.Copilot.Contracts\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\NavigateTo\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\NuGet\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\NuGetRecommender\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\OpenFolder\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Performance Tools\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Project\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ProjectSystemQuery\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ReferenceManager\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Search\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\TestWindow\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\TextMate\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VC\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Windows.Forms\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\XamlDiagnostics\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\XamlLanguageService\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\XamlTaskList\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\BenchmarkDotNet\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\CppBuildInsights\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\CpuSampling\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Database\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Debugger\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\DiagnosticsHub\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\DotNetAsync\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\DotNetCounters\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\DotNetObjectAlloc\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\EventsViewer\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\ExtensionManager\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\FileIO\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Instrumentation\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\ParallelDebugger\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\PerfMarkers\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\TreeNavigation\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\UserMarks\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\GraphProviderPackage\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\ClientDiagnostics\AppResponsiveness\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\CMake\Client\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\EBF\TestExplorer\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Editorconfig\Command\extension.vsixmanifest.
+2026/6/18 11:28:31 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Editorconfig\Wizard\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Language\GenerateType\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Profiler\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VBCSharp\ExpressionEvaluators\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VBCSharp\LanguageServices\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VBCSharp\SourceBasedTestDiscovery\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VC\CodeLens\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VC\Copilot\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VC\Debugger\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VC\LanguageServer\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VC\Project\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VisualStudio\Editors\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\CppBuildInsights\Collector\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Debugger\Visualizers\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\Providers\ManagedProvider\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\Providers\NativeCode\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\Providers\Solution\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\extension.vsixmanifest.
+2026/6/18 11:28:32 - Found extension manifest at D:\Program Files\VS18\Common7\IDE\CommonExtensions\Microsoft\VBCSharp\LanguageServices\Core\extension.vsixmanifest.
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'ef918f69-be54-4b44-b381-81d6cecef939' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'ef918f69-be54-4b44-b381-81d6cecef939' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'mstestProjectTemplate' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'mstestProjectTemplate' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Debugger.VsDbg.Integration.7B06A237-37E6-4260-A5D5-BC8C5BFC851D' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Debugger.VsDbg.Integration.7B06A237-37E6-4260-A5D5-BC8C5BFC851D' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Package.NodeJs.9ecec6f7-3c09-4cb4-ab9c-54b1e65defee' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Package.NodeJs.9ecec6f7-3c09-4cb4-ab9c-54b1e65defee' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'MSTestDesktopVB.Microsoft.c6c7fff6-20cb-405d-9ad4-a60a6d0c55d9' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'MSTestDesktopVB.Microsoft.c6c7fff6-20cb-405d-9ad4-a60a6d0c55d9' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.Vsix.TemplatesPackage' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.Vsix.TemplatesPackage' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Templates.AssemblyInfo.Wizard' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Templates.AssemblyInfo.Wizard' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.TestPlatform.VSIX.Microsoft.0e51abf6-9f5f-401e-a812-4043b87acabf' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.TestPlatform.VSIX.Microsoft.0e51abf6-9f5f-401e-a812-4043b87acabf' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.SDK' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.SDK' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Cache.Service' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Cache.Service' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Copilot.Testing.UI' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Copilot.Testing.UI' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'E639B534-6B03-4AE9-B708-9162340B7D1B' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'E639B534-6B03-4AE9-B708-9162340B7D1B' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'ClickOnceProvider.13ff266c-3231-421f-870e-f31a8ca48395' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'ClickOnceProvider.13ff266c-3231-421f-870e-f31a8ca48395' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'ConnectedServices.897486C9-63BD-48D3-8A33-CB770FBD0723' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'ConnectedServices.897486C9-63BD-48D3-8A33-CB770FBD0723' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension '7B469DDE-BFCC-4975-9C6E-154583ED3672' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension '7B469DDE-BFCC-4975-9C6E-154583ED3672' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'VisualStudio.GitHub.Copilot' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'VisualStudio.GitHub.Copilot' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Debugger.VSCodeDebuggerHost.Microsoft.42741dc7-574b-4d5b-b8d7-02b7d23cbc85' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Debugger.VSCodeDebuggerHost.Microsoft.42741dc7-574b-4d5b-b8d7-02b7d23cbc85' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Debugger.BrokeredServices' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.Debugger.BrokeredServices' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'IntelliCode.VSIX.598224b2-b987-401b-8509-f568d0c0b946' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'IntelliCode.VSIX.598224b2-b987-401b-8509-f568d0c0b946' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.IntelliCode.CSharp' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.IntelliCode.CSharp' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.LiveShare.VSCore' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.LiveShare.VSCore' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'EDDCB5BE-3C18-444E-8E50-AE06CD345872' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'EDDCB5BE-3C18-444E-8E50-AE06CD345872' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension '10143FCD-81D4-434C-8360-6557F1C053E9' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension '10143FCD-81D4-434C-8360-6557F1C053E9' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'E9E7F832-34FD-43F8-BACF-39D21037E93A' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'E9E7F832-34FD-43F8-BACF-39D21037E93A' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ResourceExplorer' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'Microsoft.VisualStudio.ResourceExplorer' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension '3B5EAFB3-87E4-4986-8924-D24DF860D894' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension '3B5EAFB3-87E4-4986-8924-D24DF860D894' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:32 - Setting discovered per-machine extension 'WCFSVCREF.4E55C53D-1367-4057-9DA7-2507AFF68A55' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:32 - Extension 'WCFSVCREF.4E55C53D-1367-4057-9DA7-2507AFF68A55' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '1D7A611D-F1E7-4E23-91D6-C64426EBE6B5' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '1D7A611D-F1E7-4E23-91D6-C64426EBE6B5' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'A7E9F2C1-8B4D-4F5E-9A3C-7D6E5F8A9B2C' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'A7E9F2C1-8B4D-4F5E-9A3C-7D6E5F8A9B2C' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'F8C3E2D1-9A6B-4F3E-8C7D-2E5F1A9B3C4E' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'F8C3E2D1-9A6B-4F3E-8C7D-2E5F1A9B3C4E' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'E8105105-1014-4688-9F62-52186FEBF19B' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'E8105105-1014-4688-9F62-52186FEBF19B' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Sdk.ProjectSystem' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Sdk.ProjectSystem' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '157a4c97-f489-4efd-8700-3b50d586fa58' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '157a4c97-f489-4efd-8700-3b50d586fa58' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'CDA2D886-5BCE-406D-BB46-08B20D3B3E96' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'CDA2D886-5BCE-406D-BB46-08B20D3B3E96' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Modeling.Extension' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Modeling.Extension' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '96492FC7-7BC6-46F7-8559-66BB4E09FD1E' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '96492FC7-7BC6-46F7-8559-66BB4E09FD1E' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '81da0100-e6db-4783-91ea-c38c3fa1b81e' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '81da0100-e6db-4783-91ea-c38c3fa1b81e' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '6e008c95-9cf6-47cd-9ecd-cfdf33277f8c' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '6e008c95-9cf6-47cd-9ecd-cfdf33277f8c' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VCClassWizard.ClassWizardPackage' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VCClassWizard.ClassWizardPackage' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '614747DE-4215-4F0B-B663-DAC4DB7E44F8' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '614747DE-4215-4F0B-B663-DAC4DB7E44F8' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.DataDesign' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.DataDesign' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'CodeCoverage.Microsoft.f47a268a-bba9-442d-ac61-eef97f906458' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'CodeCoverage.Microsoft.f47a268a-bba9-442d-ac61-eef97f906458' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Platform.CallHierarchy' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Platform.CallHierarchy' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'ClientDiagnostics..ac2d8bbe-fced-4277-8f61-24cecafa06b6' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'ClientDiagnostics..ac2d8bbe-fced-4277-8f61-24cecafa06b6' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.CMake.VC.526FBDAA-5C95-4044-8131-A5B7057781B1' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.CMake.VC.526FBDAA-5C95-4044-8131-A5B7057781B1' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.CodeAnalysis' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.CodeAnalysis' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.DesignTools.XamlDesignerHost' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.DesignTools.XamlDesignerHost' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Workspace.ExternalBuildFramework.F3641056-6B12-4C85-A36F-77736BEA3FC9' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Workspace.ExternalBuildFramework.F3641056-6B12-4C85-A36F-77736BEA3FC9' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Platform.Editor' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Platform.Editor' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ErrorList' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.ErrorList' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Extensibility.Container' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Extensibility.Container' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Extensibility.Project' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Extensibility.Project' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'VisualFSharp' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'VisualFSharp' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.HotReload' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.HotReload' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Identity' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Identity' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.Developer.IdentityServiceGS' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.Developer.IdentityServiceGS' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'd5009e66-baab-4459-8792-31b287e829ba' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'd5009e66-baab-4459-8792-31b287e829ba' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension '1F42C6D0-F876-4AF0-8185-1BEB0A325BB2' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension '1F42C6D0-F876-4AF0-8185-1BEB0A325BB2' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.LanguageServer' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.LanguageServer' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Platform.Markdown' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Platform.Markdown' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Copilot.Contracts' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Copilot.Contracts' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Platform.NavigateTo' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.Platform.NavigateTo' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'NuGet.72c5d240-f742-48d4-a0f1-7016671e405b' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'NuGet.72c5d240-f742-48d4-a0f1-7016671e405b' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'NuGetRecommender.1c74c0d3-19bc-4e51-a0f1-5258a3023d2b' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'NuGetRecommender.1c74c0d3-19bc-4e51-a0f1-5258a3023d2b' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.AnyCode' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.AnyCode' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.PerformanceTools.EditorIntegration' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.PerformanceTools.EditorIntegration' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ProjectSystem' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.ProjectSystem' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ProjectServices' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.ProjectServices' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ProjectSystem.Query' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.ProjectSystem.Query' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:33 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ReferenceManager' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:33 - Extension 'Microsoft.VisualStudio.ReferenceManager' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Platform.Search' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Platform.Search' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'TestWindow.Microsoft.0771d463-d74d-4e95-aac2-39d3c7ec1f97' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'TestWindow.Microsoft.0771d463-d74d-4e95-aac2-39d3c7ec1f97' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.TextMateGrammars' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.TextMateGrammars' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.VC' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.VC' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'ACD83F93-440C-4EDD-B086-436F5852F4E1' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'ACD83F93-440C-4EDD-B086-436F5852F4E1' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.DesignTools.Diagnostics' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.DesignTools.Diagnostics' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.DesignTools.XamlLanguageService' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.DesignTools.XamlLanguageService' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.DesignTools.XamlTaskList' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.DesignTools.XamlTaskList' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'BenchmarkDotNet.Microsoft Corp..b880d9be-372a-40bf-9aec-0801dd3a2b5d' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'BenchmarkDotNet.Microsoft Corp..b880d9be-372a-40bf-9aec-0801dd3a2b5d' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'CppBuildInsights.Microsoft Corp..8332E269-72A4-4020-B678-0AAA2A6562F5' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'CppBuildInsights.Microsoft Corp..8332E269-72A4-4020-B678-0AAA2A6562F5' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'CpuSampling.Microsoft Corp..7cdb3050-b7a1-4c26-8480-0769a8432ee7' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'CpuSampling.Microsoft Corp..7cdb3050-b7a1-4c26-8480-0769a8432ee7' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'DatabaseTool.Microsoft Corp..94b63a54-1218-4d29-adff-ae2f856c67f4' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'DatabaseTool.Microsoft Corp..94b63a54-1218-4d29-adff-ae2f856c67f4' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'VsDebugPresentationPackage' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'VsDebugPresentationPackage' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension '22512d50-40bc-4dea-89b1-21d70bb4218e' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension '22512d50-40bc-4dea-89b1-21d70bb4218e' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'DotNetAsync.Microsoft Corp..b880d9be-372a-40bf-9aec-0801dd3a2b5d' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'DotNetAsync.Microsoft Corp..b880d9be-372a-40bf-9aec-0801dd3a2b5d' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'DotNetCountersTool.Microsoft Corp..0ec7bae7-c2b8-4df3-87ed-47dccb4d0192' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'DotNetCountersTool.Microsoft Corp..0ec7bae7-c2b8-4df3-87ed-47dccb4d0192' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'DotNetObjectAllocation.Microsoft Corp..2205b5d8-e06d-453d-80b8-dcea82c6dd5b' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'DotNetObjectAllocation.Microsoft Corp..2205b5d8-e06d-453d-80b8-dcea82c6dd5b' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'EventsViewerTool.Microsoft Corp..01FAD7C8-77EC-4E88-9F80-C88FA0055252' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'EventsViewerTool.Microsoft Corp..01FAD7C8-77EC-4E88-9F80-C88FA0055252' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.ExtensionManager.Implementation' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.ExtensionManager.Implementation' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'FileIO.Microsoft Corp..96f6ae6f-3915-41b7-aadb-bcf77c540729' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'FileIO.Microsoft Corp..96f6ae6f-3915-41b7-aadb-bcf77c540729' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Instrumentation.Microsoft Corp..7cdb3050-b7a1-4c26-8480-0769a8432ee7' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Instrumentation.Microsoft Corp..7cdb3050-b7a1-4c26-8480-0769a8432ee7' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'ParallelDebugPackage' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'ParallelDebugPackage' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'PerfMarkers.Microsoft Corporation.5f945160-e23d-49c5-8997-e05932baa944' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'PerfMarkers.Microsoft Corporation.5f945160-e23d-49c5-8997-e05932baa944' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Platform' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Platform' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.TreeNavigation' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.TreeNavigation' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'UserMarksTool.Microsoft Corp..27656D46-B6EC-4B37-85FA-32C6C90ADCE5' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'UserMarksTool.Microsoft Corp..27656D46-B6EC-4B37-85FA-32C6C90ADCE5' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension '5F2E5E42-4192-4D79-A0D8-1D881E808829' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension '5F2E5E42-4192-4D79-A0D8-1D881E808829' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'AppResponsiveness..D57E4960-6C0D-4336-AFEF-CB2FAD5E97AD' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'AppResponsiveness..D57E4960-6C0D-4336-AFEF-CB2FAD5E97AD' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.CMake.VC.3DA3EDC9-446F-467A-82C0-260057228811' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.CMake.VC.3DA3EDC9-446F-467A-82C0-260057228811' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'MS.VS.Workspace.EBF.TestProvider.E7C2F617-305E-4EFE-A0AB-46C392988EAF' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'MS.VS.Workspace.EBF.TestProvider.E7C2F617-305E-4EFE-A0AB-46C392988EAF' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Templates.Editorconfig.Command' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Templates.Editorconfig.Command' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Templates.Editorconfig.Wizard.Setup' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Templates.Editorconfig.Wizard.Setup' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Language.GenerateType' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Language.GenerateType' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.TestWindow.Profiler.0e4de14d-16c3-43b8-a5a4-e8d19fd1a8bc' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.TestWindow.Profiler.0e4de14d-16c3-43b8-a5a4-e8d19fd1a8bc' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension '21BAC26D-2935-4D0D-A282-AD647E2592B5' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension '21BAC26D-2935-4D0D-A282-AD647E2592B5' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension '0b5e8ddb-f12d-4131-a71d-77acc26a798f' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension '0b5e8ddb-f12d-4131-a71d-77acc26a798f' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension '100cce4d-b061-4215-8fcd-9cb9334929b3' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension '100cce4d-b061-4215-8fcd-9cb9334929b3' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.VC.CodeLens' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.VC.CodeLens' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.VC.Copilot' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.VC.Copilot' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'CppDebug' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'CppDebug' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.VC.LanguageServer' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.VC.LanguageServer' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Project.VisualC' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Project.VisualC' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'F6B5EACA-7FA1-4591-8D40-A38234763621' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'F6B5EACA-7FA1-4591-8D40-A38234763621' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'CppBuildInsightsCollector.218bbdca-4b88-4917-8ca6-22fce8e5303b' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'CppBuildInsightsCollector.218bbdca-4b88-4917-8ca6-22fce8e5303b' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.DebuggerVisualizers.Package' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.DebuggerVisualizers.Package' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Progression.LanguageService.ManagedProvider' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Progression.LanguageService.ManagedProvider' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Progression.Native.CodeProvider' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Progression.Native.CodeProvider' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.Progression.VSProvider' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.Progression.VSProvider' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:34 - Setting discovered per-machine extension 'Microsoft.VisualStudio.TeamFoundation.TeamExplorer.MinGit' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:34 - Extension 'Microsoft.VisualStudio.TeamFoundation.TeamExplorer.MinGit' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:35 - Setting discovered per-machine extension '77E1B4B1-51C4-4B24-9CA2-3CFAC4943DFF' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:35 - Extension '77E1B4B1-51C4-4B24-9CA2-3CFAC4943DFF' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:35 - Capping recursion at 5 directories in each extension root 'C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions' due to 'default limit behavior'.
+2026/6/18 11:28:35 - Found extension manifest at C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions\Microsoft\Windows Kits\10\Desktop SDK\extension.vsixmanifest.
+2026/6/18 11:28:35 - Found extension manifest at C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions\Microsoft\Windows Kits\10\Windows Store SDK\extension.vsixmanifest.
+2026/6/18 11:28:35 - Capping recursion at 5 directories in each extension root 'C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions' due to 'default limit behavior'.
+2026/6/18 11:28:35 - Found extension manifest at C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions\Microsoft\Windows Kits\10\Desktop SDK\extension.vsixmanifest.
+2026/6/18 11:28:35 - Found extension manifest at C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions\Microsoft\Windows Kits\10\Windows Store SDK\extension.vsixmanifest.
+2026/6/18 11:28:35 - Setting discovered per-machine extension 'Microsoft.Windows.DevelopmentKit.Desktop' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:35 - Extension 'Microsoft.Windows.DevelopmentKit.Desktop' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:35 - Setting discovered per-machine extension 'Microsoft.Windows.DevelopmentKit.WindowsStore' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:35 - Extension 'Microsoft.Windows.DevelopmentKit.WindowsStore' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:35 - Setting discovered per-machine extension 'Microsoft.Windows.DevelopmentKit.Desktop' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:35 - Extension 'Microsoft.Windows.DevelopmentKit.Desktop' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:35 - Discovered extension with identifier 'Microsoft.Windows.DevelopmentKit.Desktop' at 'C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions\Microsoft\Windows Kits\10\Desktop SDK\' is already in the cache.
+2026/6/18 11:28:35 - Discovered extension 'Microsoft.Windows.DevelopmentKit.Desktop' is already in the cache. Skipping it.
+2026/6/18 11:28:35 - Setting discovered per-machine extension 'Microsoft.Windows.DevelopmentKit.WindowsStore' initial state to InitialExtensionState { State = Enabled, Reason = Per-machine extension enabled by default }
+2026/6/18 11:28:35 - Extension 'Microsoft.Windows.DevelopmentKit.WindowsStore' initial state set to 'Enabled' because 'Per-machine extension enabled by default'
+2026/6/18 11:28:35 - Discovered extension with identifier 'Microsoft.Windows.DevelopmentKit.WindowsStore' at 'C:\Program Files (x86)\Common Files\Microsoft\ExtensionManager\Extensions\Microsoft\Windows Kits\10\Windows Store SDK\' is already in the cache.
+2026/6/18 11:28:35 - Discovered extension 'Microsoft.Windows.DevelopmentKit.WindowsStore' is already in the cache. Skipping it.
+2026/6/18 11:28:35 - Extension 'BrightXaml.c6b5c335-85e8-4243-bdf1-2b6468178ad1' initial state set to 'Enabled'
+2026/6/18 11:28:35 - Discovered extension with identifier 'BrightXaml.c6b5c335-85e8-4243-bdf1-2b6468178ad1' at 'D:\Program Files\VS18\Common7\IDE\VSExtensions\phcgyrjb.313\' is already in the cache.
+2026/6/18 11:28:35 - Discovered extension 'BrightXaml.c6b5c335-85e8-4243-bdf1-2b6468178ad1' is already in the cache. Skipping it.
+2026/6/18 11:28:35 - Extension 'Microsoft.VisualStudio.Copilot.LogViewerExtension' initial state set to 'Enabled'
+2026/6/18 11:28:35 - Discovered extension with identifier 'Microsoft.VisualStudio.Copilot.LogViewerExtension' at 'D:\Program Files\VS18\Common7\IDE\VSExtensions\Microsoft\CopilotLogViewer\' is already in the cache.
+2026/6/18 11:28:35 - Discovered extension 'Microsoft.VisualStudio.Copilot.LogViewerExtension' is already in the cache. Skipping it.
+2026/6/18 11:28:35 - Extension 'BrightXaml.c6b5c335-85e8-4243-bdf1-2b6468178ad1' initial state set to 'Enabled'
+2026/6/18 11:28:35 - Extension 'Microsoft.VisualStudio.Copilot.LogViewerExtension' initial state set to 'Enabled'
+2026/6/18 11:28:35 - ID 为“54803a44-49e0-4935-bba4-7d7d91682273”的扩展未安装到 Visual Studio Community 2026。
+2026/6/18 11:28:35 - 找到的已安装产品 - 全局位置
+2026/6/18 11:28:35 - 扩展详细信息...
+2026/6/18 11:28:35 - 	Identifier         : 54803a44-49e0-4935-bba4-7d7d91682273
+2026/6/18 11:28:35 - 	Name               : GitLab Extension for Visual Studio
+2026/6/18 11:28:35 - 	Author             : MysticBoy
+2026/6/18 11:28:35 - 	Version            : 1.3.0
+2026/6/18 11:28:35 - 	Description        : A Visual Studio Extension that brings the GitLab Flow into Visual Studio. Supports Visual Studio 2022 and 2026.
+2026/6/18 11:28:35 - 	Locale             : en-US
+2026/6/18 11:28:35 - 	MoreInfoURL        : https://github.com/maikebing/GitLab.VisualStudio
+2026/6/18 11:28:35 - 	InstalledByMSI     : True
+2026/6/18 11:28:35 - 	SupportedFrameworkVersionRange : [4.5,)
+2026/6/18 11:28:35 - 	SignatureState     : Unsigned
+2026/6/18 11:28:35 - 	支持的产品              : 
+2026/6/18 11:28:35 - 		Microsoft.VisualStudio.Community
+2026/6/18 11:28:35 - 			Version : [17.0,19.0)
+2026/6/18 11:28:35 - 			ProductArchitecture : amd64
+2026/6/18 11:28:35 - 		Microsoft.VisualStudio.Community
+2026/6/18 11:28:35 - 			Version : [17.0,19.0)
+2026/6/18 11:28:35 - 			ProductArchitecture : arm64
+2026/6/18 11:28:35 - 		Microsoft.VisualStudio.Pro
+2026/6/18 11:28:35 - 			Version : [17.0,19.0)
+2026/6/18 11:28:35 - 			ProductArchitecture : amd64
+2026/6/18 11:28:35 - 		Microsoft.VisualStudio.Pro
+2026/6/18 11:28:35 - 			Version : [17.0,19.0)
+2026/6/18 11:28:35 - 			ProductArchitecture : arm64
+2026/6/18 11:28:35 - 		Microsoft.VisualStudio.Enterprise
+2026/6/18 11:28:35 - 			Version : [17.0,19.0)
+2026/6/18 11:28:35 - 			ProductArchitecture : amd64
+2026/6/18 11:28:35 - 		Microsoft.VisualStudio.Enterprise
+2026/6/18 11:28:35 - 			Version : [17.0,19.0)
+2026/6/18 11:28:35 - 			ProductArchitecture : arm64
+2026/6/18 11:28:35 - 	引用                 : 
+2026/6/18 11:28:35 - 		-------------------------------------------------------
+2026/6/18 11:28:35 - 		Identifier   : Microsoft.VisualStudio.MPF.17.0
+2026/6/18 11:28:35 - 		Name         : Visual Studio MPF 17.0
+2026/6/18 11:28:35 - 		Version      : [17.0,19.0)
+2026/6/18 11:28:35 - 		MoreInfoURL  : 
+2026/6/18 11:28:35 - 		Nested       : No
+2026/6/18 11:28:35 - 		-------------------------------------------------------
+2026/6/18 11:28:35 - 		Identifier   : Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions
+2026/6/18 11:28:35 - 		Name         : Team Explorer
+2026/6/18 11:28:35 - 		Version      : [17.0.31918.5,19.0)
+2026/6/18 11:28:35 - 		MoreInfoURL  : 
+2026/6/18 11:28:35 - 		Nested       : No
+2026/6/18 11:28:35 - 	系统必备               : 
+2026/6/18 11:28:35 - 		-------------------------------------------------------
+2026/6/18 11:28:35 - 		Identifier   : Microsoft.VisualStudio.Component.CoreEditor
+2026/6/18 11:28:35 - 		Name         : Visual Studio 核心编辑器
+2026/6/18 11:28:35 - 		Version      : [17.0.31804.368,19.0)
+2026/6/18 11:28:35 - 签名详细信息...
+2026/6/18 11:28:35 - 	Extension is not signed.
+2026/6/18 11:28:37 - BEGIN: Processing extension pack
+2026/6/18 11:28:37 - END: Processing extension pack
+2026/6/18 11:28:37 - Initializing Install...
+2026/6/18 11:28:37 - 正在搜索适用的产品...
+2026/6/18 11:28:37 - 找到的已安装产品 - Visual Studio Community 2026
+2026/6/18 11:28:37 - Failed to get 'IVsAppCommandLine' service
+2026/6/18 11:28:37 - Local compatibility list path: C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\CompatibilityList.xml - Timestamp: 134201764628031807
+2026/6/18 11:28:37 - Installed compatibility list path: D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml - Timestamp: 134255282108646403
+2026/6/18 11:28:37 - Using installed compatibility list file at 'D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml'.
+2026/6/18 11:28:37 - Try downloading compatibility list file.
+2026/6/18 11:28:37 - Visual Studio Version: 18.7.11903.348
+2026/6/18 11:28:37 - Parsing compatibility list file - D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 5fb7364d-2e8c-44a4-95eb-2a382e30fec9
+Extension Version - (,0.5)
+Extension Action - Disable
+Product Version - [14.0.23000,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 3a012d4e-6057-4e7c-8123-6d4be1d4723c-RC
+Extension Version - (,1.0)
+Extension Action - Disable
+Product Version - [14.0.22528,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 3a012d4e-6057-4e7c-8123-6d4be1d4723c
+Extension Version - (,42.42.42.42)
+Extension Action - Disable
+Product Version - (,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - DeploymentProject.14.0.VSIX.42D3833A-56C3-440E-8127-558CCE16AE00
+Extension Version - (,2.6)
+Extension Action - Warning
+Product Version - [14.0.23010,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 177DDE05-53AD-4611-A5A7-1D52F75AA3F0
+Extension Version - (,2.6)
+Extension Action - Warning
+Product Version - [14.0.23010,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - VSColorThemeEditor.26c6a2c2-1956-480f-845d-c32d9a14e1b4
+Extension Version - (,)
+Extension Action - Warning
+Product Version - [16.0.28608.199,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - GitHub.Copilot
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - VS.GitHub.Copilot
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - VS.GitHub.Copilot.Service
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - NuGetSolver.ecccc3de-a53e-4834-8b5d-7f07b8633436
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - Microsoft.NET.UpgradeAssistant
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - Microsoft.AppCAT
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - Microsoft.GitHub.Copilot.Upgrade.NET
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - AppModernizationForDotNet
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11026.187,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - TimeStampMargin2022.255e8b14-4a53-4eb7-89a7-7ab741c1f612
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.3.11304.161,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - ID 为“54803a44-49e0-4935-bba4-7d7d91682273”的扩展未安装到 Visual Studio Community 2026。
+2026/6/18 11:28:37 - 找到的已安装产品 - 全局位置
+2026/6/18 11:28:37 - 扩展详细信息...
+2026/6/18 11:28:37 - 	Identifier         : 54803a44-49e0-4935-bba4-7d7d91682273
+2026/6/18 11:28:37 - 	Name               : GitLab Extension for Visual Studio
+2026/6/18 11:28:37 - 	Author             : MysticBoy
+2026/6/18 11:28:37 - 	Version            : 1.3.0
+2026/6/18 11:28:37 - 	Description        : A Visual Studio Extension that brings the GitLab Flow into Visual Studio. Supports Visual Studio 2022 and 2026.
+2026/6/18 11:28:37 - 	Locale             : en-US
+2026/6/18 11:28:37 - 	MoreInfoURL        : https://github.com/maikebing/GitLab.VisualStudio
+2026/6/18 11:28:37 - 	InstalledByMSI     : True
+2026/6/18 11:28:37 - 	SupportedFrameworkVersionRange : [4.5,)
+2026/6/18 11:28:37 - 	SignatureState     : Unsigned
+2026/6/18 11:28:37 - 	支持的产品              : 
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Community
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : amd64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Community
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : arm64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Pro
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : amd64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Pro
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : arm64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Enterprise
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : amd64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Enterprise
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : arm64
+2026/6/18 11:28:37 - 	引用                 : 
+2026/6/18 11:28:37 - 		-------------------------------------------------------
+2026/6/18 11:28:37 - 		Identifier   : Microsoft.VisualStudio.MPF.17.0
+2026/6/18 11:28:37 - 		Name         : Visual Studio MPF 17.0
+2026/6/18 11:28:37 - 		Version      : [17.0,19.0)
+2026/6/18 11:28:37 - 		MoreInfoURL  : 
+2026/6/18 11:28:37 - 		Nested       : No
+2026/6/18 11:28:37 - 		-------------------------------------------------------
+2026/6/18 11:28:37 - 		Identifier   : Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions
+2026/6/18 11:28:37 - 		Name         : Team Explorer
+2026/6/18 11:28:37 - 		Version      : [17.0.31918.5,19.0)
+2026/6/18 11:28:37 - 		MoreInfoURL  : 
+2026/6/18 11:28:37 - 		Nested       : No
+2026/6/18 11:28:37 - 	系统必备               : 
+2026/6/18 11:28:37 - 		-------------------------------------------------------
+2026/6/18 11:28:37 - 		Identifier   : Microsoft.VisualStudio.Component.CoreEditor
+2026/6/18 11:28:37 - 		Name         : Visual Studio 核心编辑器
+2026/6/18 11:28:37 - 		Version      : [17.0.31804.368,19.0)
+2026/6/18 11:28:37 - 签名详细信息...
+2026/6/18 11:28:37 - 	Extension is not signed.
+2026/6/18 11:28:37 - Initializing Install...
+2026/6/18 11:28:37 - 正在搜索适用的产品...
+2026/6/18 11:28:37 - 找到的已安装产品 - Visual Studio Community 2026
+2026/6/18 11:28:37 - Failed to get 'IVsAppCommandLine' service
+2026/6/18 11:28:37 - Local compatibility list path: C:\Users\a\AppData\Local\Microsoft\VisualStudio\18.0_78a5787a\Extensions\CompatibilityList.xml - Timestamp: 134201764628031807
+2026/6/18 11:28:37 - Installed compatibility list path: D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml - Timestamp: 134255282108646403
+2026/6/18 11:28:37 - Using installed compatibility list file at 'D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml'.
+2026/6/18 11:28:37 - Try downloading compatibility list file.
+2026/6/18 11:28:37 - Visual Studio Version: 18.7.11903.348
+2026/6/18 11:28:37 - Parsing compatibility list file - D:\Program Files\VS18\Common7\IDE\CommonExtensions\Platform\Shell\CompatibilityList.xml
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 5fb7364d-2e8c-44a4-95eb-2a382e30fec9
+Extension Version - (,0.5)
+Extension Action - Disable
+Product Version - [14.0.23000,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 3a012d4e-6057-4e7c-8123-6d4be1d4723c-RC
+Extension Version - (,1.0)
+Extension Action - Disable
+Product Version - [14.0.22528,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 3a012d4e-6057-4e7c-8123-6d4be1d4723c
+Extension Version - (,42.42.42.42)
+Extension Action - Disable
+Product Version - (,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - DeploymentProject.14.0.VSIX.42D3833A-56C3-440E-8127-558CCE16AE00
+Extension Version - (,2.6)
+Extension Action - Warning
+Product Version - [14.0.23010,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - 177DDE05-53AD-4611-A5A7-1D52F75AA3F0
+Extension Version - (,2.6)
+Extension Action - Warning
+Product Version - [14.0.23010,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - VSColorThemeEditor.26c6a2c2-1956-480f-845d-c32d9a14e1b4
+Extension Version - (,)
+Extension Action - Warning
+Product Version - [16.0.28608.199,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - GitHub.Copilot
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - VS.GitHub.Copilot
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - VS.GitHub.Copilot.Service
+Extension Version - [0.0.1,)
+Extension Action - Disable
+Product Version - [17.10,)
+Disable During Update Configuration - True
+Incompatible Reason - Copilot Transition
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - NuGetSolver.ecccc3de-a53e-4834-8b5d-7f07b8633436
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0,)
+Disable During Update Configuration - False
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - Microsoft.NET.UpgradeAssistant
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - Microsoft.AppCAT
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - Microsoft.GitHub.Copilot.Upgrade.NET
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11018.21,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - AppModernizationForDotNet
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.0.11026.187,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - Found extension in incompatibility list
+Extension ID - TimeStampMargin2022.255e8b14-4a53-4eb7-89a7-7ab741c1f612
+Extension Version - [0.1,)
+Extension Action - Disable
+Product Version - [18.3.11304.161,)
+Disable During Update Configuration - True
+Incompatible Reason - 
+2026/6/18 11:28:37 - ID 为“54803a44-49e0-4935-bba4-7d7d91682273”的扩展未安装到 Visual Studio Community 2026。
+2026/6/18 11:28:37 - 找到的已安装产品 - 全局位置
+2026/6/18 11:28:37 - 扩展详细信息...
+2026/6/18 11:28:37 - 	Identifier         : 54803a44-49e0-4935-bba4-7d7d91682273
+2026/6/18 11:28:37 - 	Name               : GitLab Extension for Visual Studio
+2026/6/18 11:28:37 - 	Author             : MysticBoy
+2026/6/18 11:28:37 - 	Version            : 1.3.0
+2026/6/18 11:28:37 - 	Description        : A Visual Studio Extension that brings the GitLab Flow into Visual Studio. Supports Visual Studio 2022 and 2026.
+2026/6/18 11:28:37 - 	Locale             : en-US
+2026/6/18 11:28:37 - 	MoreInfoURL        : https://github.com/maikebing/GitLab.VisualStudio
+2026/6/18 11:28:37 - 	InstalledByMSI     : True
+2026/6/18 11:28:37 - 	SupportedFrameworkVersionRange : [4.5,)
+2026/6/18 11:28:37 - 	SignatureState     : Unsigned
+2026/6/18 11:28:37 - 	支持的产品              : 
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Community
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : amd64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Community
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : arm64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Pro
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : amd64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Pro
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : arm64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Enterprise
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : amd64
+2026/6/18 11:28:37 - 		Microsoft.VisualStudio.Enterprise
+2026/6/18 11:28:37 - 			Version : [17.0,19.0)
+2026/6/18 11:28:37 - 			ProductArchitecture : arm64
+2026/6/18 11:28:37 - 	引用                 : 
+2026/6/18 11:28:37 - 		-------------------------------------------------------
+2026/6/18 11:28:37 - 		Identifier   : Microsoft.VisualStudio.MPF.17.0
+2026/6/18 11:28:37 - 		Name         : Visual Studio MPF 17.0
+2026/6/18 11:28:37 - 		Version      : [17.0,19.0)
+2026/6/18 11:28:37 - 		MoreInfoURL  : 
+2026/6/18 11:28:37 - 		Nested       : No
+2026/6/18 11:28:37 - 		-------------------------------------------------------
+2026/6/18 11:28:37 - 		Identifier   : Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions
+2026/6/18 11:28:37 - 		Name         : Team Explorer
+2026/6/18 11:28:37 - 		Version      : [17.0.31918.5,19.0)
+2026/6/18 11:28:37 - 		MoreInfoURL  : 
+2026/6/18 11:28:37 - 		Nested       : No
+2026/6/18 11:28:37 - 	系统必备               : 
+2026/6/18 11:28:37 - 		-------------------------------------------------------
+2026/6/18 11:28:37 - 		Identifier   : Microsoft.VisualStudio.Component.CoreEditor
+2026/6/18 11:28:37 - 		Name         : Visual Studio 核心编辑器
+2026/6/18 11:28:37 - 		Version      : [17.0.31804.368,19.0)
+2026/6/18 11:28:37 - 签名详细信息...
+2026/6/18 11:28:37 - 	Extension is not signed.
+2026/6/18 11:28:37 - Compatibility list file in server is same from local path.
+2026/6/18 11:28:37 - File content is not updated or not found while downloading the compatibility list file.
+2026/6/18 11:28:38 - Compatibility list file in server is same from local path.
+2026/6/18 11:28:38 - File content is not updated or not found while downloading the compatibility list file.
+2026/6/18 11:28:46 - Blocking processes:
+2026/6/18 11:28:46 - InstallProgressPage ChangeType: 'SingleInstall' operationCount: '2' Text: '正在安装 GitLab Extension for Visual Studio...'
+2026/6/18 11:28:46 - 已选择以下目标产品...
+2026/6/18 11:28:46 - 	Visual Studio Community 2026
+2026/6/18 11:28:46 - 正在开始将扩展安装到 Visual Studio Community 2026...
+2026/6/18 11:28:46 - Allow incremental major version dependencies
+2026/6/18 11:28:46 - Beginning installation of extension: 'GitLab Extension for Visual Studio' Identifier '54803a44-49e0-4935-bba4-7d7d91682273' Version '1.3.0' InstallFlags: AllowIncrementalMajorVersionDependencies PerMachine: False.
+2026/6/18 11:28:46 - Extension is installed by MSI
+通过扩展和更新安装程序安装扩展时，扩展“GitLab Extension for Visual Studio”中的 InstalledByMSI 元素不能为 "true"。仅当 MSI 备有扩展清单文件时，该元素才可以为 "true"。
+
+
+2026/6/18 11:28:46 - Installation of extension '54803a44-49e0-4935-bba4-7d7d91682273' failed with InstallByMsiException: 通过扩展和更新安装程序安装扩展时，扩展“GitLab Extension for Visual Studio”中的 InstalledByMSI 元素不能为 "true"。仅当 MSI 备有扩展清单文件时，该元素才可以为 "true"。. Rolling back.
+2026/6/18 11:28:46 - Installation of extension '54803a44-49e0-4935-bba4-7d7d91682273' failed.
+通过扩展和更新安装程序安装扩展时，扩展“GitLab Extension for Visual Studio”中的 InstalledByMSI 元素不能为 "true"。仅当 MSI 备有扩展清单文件时，该元素才可以为 "true"。
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.ExtensionRequiresAdditionalOperationForInstall(IInstallableExtension extension, IInstalledExtensionList modifiedInstalledExtensionsList, Boolean isNestedExtension, InstallFlags flags, Boolean& performExtensionUpdate)
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.InstallInternal(IInstallableExtension extension, InstallFlags installFlags, IDictionary`2 extensionsInstalledSoFar, List`1 extensionsUninstalledSoFar, IInstalledExtensionList modifiedInstalledExtensionsList, AsyncOperation asyncOp, IProgress`1 progress, Version targetedVsVersion)
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.BeginInstall(IInstallableExtension installableExtension, InstallFlags installFlags, AsyncOperation asyncOp, Version targetedVsVersion)
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.InstallWorker(IInstallableExtension extension, InstallFlags installFlags, AsyncOperation asyncOp)
+
+2026/6/18 11:28:46 - 安装错误: Microsoft.VisualStudio.ExtensionManager.InstallByMsiException: 通过扩展和更新安装程序安装扩展时，扩展“GitLab Extension for Visual Studio”中的 InstalledByMSI 元素不能为 "true"。仅当 MSI 备有扩展清单文件时，该元素才可以为 "true"。
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.ExtensionRequiresAdditionalOperationForInstall(IInstallableExtension extension, IInstalledExtensionList modifiedInstalledExtensionsList, Boolean isNestedExtension, InstallFlags flags, Boolean& performExtensionUpdate)
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.InstallInternal(IInstallableExtension extension, InstallFlags installFlags, IDictionary`2 extensionsInstalledSoFar, List`1 extensionsUninstalledSoFar, IInstalledExtensionList modifiedInstalledExtensionsList, AsyncOperation asyncOp, IProgress`1 progress, Version targetedVsVersion)
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.BeginInstall(IInstallableExtension installableExtension, InstallFlags installFlags, AsyncOperation asyncOp, Version targetedVsVersion)
+   在 Microsoft.VisualStudio.Extension.Management.ExtensionInstallModule.InstallWorker(IInstallableExtension extension, InstallFlags installFlags, AsyncOperation asyncOp)

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,54 @@
+# Building GitLab Extension for Visual Studio
+
+This is a Visual Studio VSIX extension targeting **.NET Framework 4.7.2**. It can only
+be built on **Windows** with Visual Studio and the Visual Studio SDK installed — it
+cannot be compiled on Linux/macOS or with the .NET (Core) SDK alone.
+
+## Prerequisites
+
+- Windows 10/11
+- **Visual Studio 2022 (17.x)** or **Visual Studio 2026 (18.x)**, any edition
+  (Community / Professional / Enterprise)
+- Workloads / individual components:
+  - **Visual Studio extension development** (VSSDK)
+  - **.NET Framework 4.7.2 targeting pack**
+  - **Team Explorer** (the extension integrates with the Team Explorer panes)
+
+## Supported Visual Studio versions
+
+The VSIX manifest install target is `[17.0,19.0)`, so the produced package installs on
+both Visual Studio 2022 and Visual Studio 2026. The extension is built as **Any CPU**
+and ships **amd64** and **arm64** install targets (the legacy 32-bit `x86` target was
+removed because Visual Studio 2022+ is a 64-bit process).
+
+## Build from the IDE
+
+1. Open `GitLabVS.sln`.
+2. Select the `Release` (or `Debug`) configuration, `Any CPU` platform.
+3. Restore NuGet packages (automatic on first build).
+4. Build the solution. The VSIX is produced at
+   `build\<Configuration>\GitLab.VisualStudio.vsix`.
+
+To debug, set `GitLab.VisualStudio` as the startup project and press F5; this launches
+the Visual Studio Experimental Instance (`/rootsuffix Exp`) with the extension loaded.
+
+## Build from the command line
+
+Run from a **Developer Command Prompt / Developer PowerShell** for your VS version so
+that `MSBuild`, `$(VsInstallRoot)` and `$(DevEnvDir)` are available (these are used to
+locate the Team Explorer assemblies):
+
+```cmd
+nuget restore GitLabVS.sln
+msbuild GitLabVS.sln /p:Configuration=Release /p:DeployExtension=false /v:m
+```
+
+## Notes for the VS2026 upgrade
+
+- `Microsoft.VisualStudio.SDK` / `Microsoft.VSSDK.BuildTools` are on the **17.14** line.
+  Per Microsoft's extension compatibility model, an extension built against the 17.x SDK
+  runs unchanged on Visual Studio 2026, so a separate 18.x build is not required.
+- Team Explorer references in `GitLab.TeamFoundation.17.csproj` resolve via
+  `$(VsInstallRoot)` / `$(DevEnvDir)` instead of a hard-coded
+  `...\2022\Professional\...` path, so the project builds against whichever VS edition
+  and version is performing the build.

--- a/docs/build.md
+++ b/docs/build.md
@@ -43,6 +43,29 @@ nuget restore GitLabVS.sln
 msbuild GitLabVS.sln /p:Configuration=Release /p:DeployExtension=false /v:m
 ```
 
+## Required local file: `GitApp.cs` (OAuth credentials)
+
+`src/GitLab.VisualStudio.UI/Properties/GitApp.cs` holds the GitLab OAuth application
+credentials and is intentionally **git-ignored** (see `.gitignore`). A clean checkout
+therefore does not contain it, and the build fails with
+`CS2001: Source file '...\Properties\GitApp.cs' could not be found` until you create it.
+
+Create the file locally with this shape:
+
+```csharp
+namespace GitLab.VisualStudio.UI.Properties
+{
+    internal static class GitApp
+    {
+        public const string client_id = "<your GitLab OAuth application id>";
+        public const string client_secret = "<your GitLab OAuth application secret>";
+    }
+}
+```
+
+The CI workflow (`.github/workflows/build.yml`) generates a placeholder version of this
+file automatically so it can validate compilation without access to real credentials.
+
 ## Notes for the VS2026 upgrade
 
 - `Microsoft.VisualStudio.SDK` / `Microsoft.VSSDK.BuildTools` are on the **17.14** line.

--- a/src/GitLab.TeamFoundation.14/GitLab.TeamFoundation.14.csproj
+++ b/src/GitLab.TeamFoundation.14/GitLab.TeamFoundation.14.csproj
@@ -93,8 +93,11 @@
     <Compile Include="Connect\GitLabInvitationSection.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Home\PipelinesNavigationItem.cs" />
+    <Compile Include="Home\GitLabSettingsSection.cs" />
     <Compile Include="Home\GitLabHomeSection.cs" />
     <Compile Include="Home\GitLabNavigationItem.cs" />
+    <Compile Include="Home\GitLabWorkItemsPage.cs" />
+    <Compile Include="Home\GitLabWorkItemsPageMode.cs" />
     <Compile Include="Home\IssuesNavigationItem.cs" />
     <Compile Include="Home\MergeRequestsNavigationItem.cs" />
     <Compile Include="Home\GraphNavigationItem.cs" />
@@ -106,6 +109,8 @@
     <Compile Include="Settings.cs" />
     <Compile Include="Sync\GitLabPublishSection.cs" />
     <Compile Include="ViewModels\ConnectSectionViewModel.cs" />
+    <Compile Include="ViewModels\GitLabSettingsViewModel.cs" />
+    <Compile Include="ViewModels\GitLabWorkItemsViewModel.cs" />
     <Compile Include="ViewModels\PublishSectionViewModel.cs" />
     <Compile Include="Views\ConnectSectionView.xaml.cs">
       <DependentUpon>ConnectSectionView.xaml</DependentUpon>
@@ -113,6 +118,8 @@
     <Compile Include="Views\PublishSectionView.xaml.cs">
       <DependentUpon>PublishSectionView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\GitLabSettingsView.cs" />
+    <Compile Include="Views\GitLabWorkItemsView.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="Views\ConnectSectionView.xaml">

--- a/src/GitLab.TeamFoundation.14/Home/GitLabNavigationItem.cs
+++ b/src/GitLab.TeamFoundation.14/Home/GitLabNavigationItem.cs
@@ -80,6 +80,16 @@ namespace GitLab.TeamFoundation.Home
             _shell.OpenUrl(url);
         }
 
+        protected void NavigateToGitLabWorkItemsPage(GitLabWorkItemsPageMode mode)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var teamExplorer = ServiceProvider.GlobalProvider.GetService(typeof(ITeamExplorer)) as ITeamExplorer;
+            if (teamExplorer != null)
+            {
+                teamExplorer.NavigateToPage(new Guid(Settings.GitLabWorkItemsPageId), mode);
+            }
+        }
+
         protected void OpenHostUrlInBrowser(string endpoint)
         {
             var url = $"{_storage.Host}/{endpoint}";

--- a/src/GitLab.TeamFoundation.14/Home/GitLabSettingsSection.cs
+++ b/src/GitLab.TeamFoundation.14/Home/GitLabSettingsSection.cs
@@ -1,0 +1,58 @@
+using GitLab.TeamFoundation.ViewModels;
+using GitLab.TeamFoundation.Views;
+using GitLab.VisualStudio.Shared;
+using Microsoft.TeamFoundation.Controls;
+using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+
+namespace GitLab.TeamFoundation.Home
+{
+    [TeamExplorerSection(Settings.GitLabSettingsSectionId, TeamExplorerPageIds.Settings, Settings.GitLabSettingsSectionPriority)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class GitLabSettingsSection : TeamExplorerSectionBase
+    {
+        private readonly IStorage _storage;
+
+        [ImportingConstructor]
+        public GitLabSettingsSection(IStorage storage)
+        {
+            _storage = storage;
+        }
+
+        protected override ITeamExplorerSection CreateViewModel(SectionInitializeEventArgs e)
+        {
+            return new TeamExplorerSectionViewModelBase
+            {
+                Title = Strings.Name
+            };
+        }
+
+        public override void Initialize(object sender, SectionInitializeEventArgs e)
+        {
+            base.Initialize(sender, e);
+            IsVisible = _storage.IsLogined;
+        }
+
+        protected override object CreateView(SectionInitializeEventArgs e)
+        {
+            return new GitLabSettingsView();
+        }
+
+        protected override void InitializeView(SectionInitializeEventArgs e)
+        {
+            var view = SectionContent as FrameworkElement;
+            if (view != null)
+            {
+                view.DataContext = new GitLabSettingsViewModel(_storage);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/GitLab.TeamFoundation.14/Home/GitLabWorkItemsPage.cs
+++ b/src/GitLab.TeamFoundation.14/Home/GitLabWorkItemsPage.cs
@@ -1,0 +1,83 @@
+using GitLab.TeamFoundation.ViewModels;
+using GitLab.TeamFoundation.Views;
+using GitLab.VisualStudio.Shared;
+using Microsoft.TeamFoundation.Controls;
+using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+
+namespace GitLab.TeamFoundation.Home
+{
+    [TeamExplorerPage(Settings.GitLabWorkItemsPageId)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class GitLabWorkItemsPage : TeamExplorerPageBase
+    {
+        private readonly IShellService _shell;
+        private readonly IStorage _storage;
+        private readonly ITeamExplorerServices _tes;
+        private readonly IWebService _web;
+
+        [ImportingConstructor]
+        public GitLabWorkItemsPage(IShellService shell, IStorage storage, ITeamExplorerServices tes, IWebService web)
+        {
+            _shell = shell;
+            _storage = storage;
+            _tes = tes;
+            _web = web;
+        }
+
+        protected override ITeamExplorerPage CreateViewModel(PageInitializeEventArgs e)
+        {
+            return new TeamExplorerPageViewModelBase
+            {
+                Title = GetTitle(GetMode(e))
+            };
+        }
+
+        protected override object CreateView(PageInitializeEventArgs e)
+        {
+            return new GitLabWorkItemsView(GetMode(e) == GitLabWorkItemsPageMode.MergeRequests);
+        }
+
+        protected override void InitializeView(PageInitializeEventArgs e)
+        {
+            var view = PageContent as FrameworkElement;
+            if (view != null)
+            {
+                view.DataContext = new GitLabWorkItemsViewModel(_storage, _web, _shell, _tes, GetMode(e));
+            }
+        }
+
+        public override void Refresh()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var view = PageContent as FrameworkElement;
+            var vm = view != null ? view.DataContext as GitLabWorkItemsViewModel : null;
+            if (vm != null)
+            {
+                vm.Refresh();
+            }
+
+            base.Refresh();
+        }
+
+        private static GitLabWorkItemsPageMode GetMode(PageInitializeEventArgs e)
+        {
+            if (e != null && e.Context is GitLabWorkItemsPageMode)
+            {
+                return (GitLabWorkItemsPageMode)e.Context;
+            }
+
+            return GitLabWorkItemsPageMode.Issues;
+        }
+
+        private static string GetTitle(GitLabWorkItemsPageMode mode)
+        {
+            return mode == GitLabWorkItemsPageMode.MergeRequests
+                ? Strings.Items_MergeRequests
+                : Strings.Items_Issues;
+        }
+    }
+}

--- a/src/GitLab.TeamFoundation.14/Home/GitLabWorkItemsPageMode.cs
+++ b/src/GitLab.TeamFoundation.14/Home/GitLabWorkItemsPageMode.cs
@@ -1,0 +1,8 @@
+namespace GitLab.TeamFoundation.Home
+{
+    public enum GitLabWorkItemsPageMode
+    {
+        Issues,
+        MergeRequests
+    }
+}

--- a/src/GitLab.TeamFoundation.14/Home/GraphNavigationItem.cs
+++ b/src/GitLab.TeamFoundation.14/Home/GraphNavigationItem.cs
@@ -17,12 +17,17 @@ namespace GitLab.TeamFoundation.Home
         {
             _tes = tes;
             Text = Strings.Items_Graph;
+            IsVisible = false;
+        }
+
+        public override void Invalidate()
+        {
+            IsVisible = false;
         }
 
         public override void Execute()
         {
-            var repo = _tes.GetActiveRepository();
-            OpenInBrowser($"graphs/{repo.Branch}");
+            IsVisible = false;
         }
     }
 }

--- a/src/GitLab.TeamFoundation.14/Home/IssuesNavigationItem.cs
+++ b/src/GitLab.TeamFoundation.14/Home/IssuesNavigationItem.cs
@@ -27,7 +27,7 @@ namespace GitLab.TeamFoundation.Home
 
         public override void Execute()
         {
-            OpenInBrowser("issues");
+            NavigateToGitLabWorkItemsPage(GitLabWorkItemsPageMode.Issues);
         }
     }
 }

--- a/src/GitLab.TeamFoundation.14/Home/MergeRequestsNavigationItem.cs
+++ b/src/GitLab.TeamFoundation.14/Home/MergeRequestsNavigationItem.cs
@@ -29,7 +29,7 @@ namespace GitLab.TeamFoundation.Home
 
         public override void Execute()
         {
-            OpenInBrowser("merge_requests");
+            NavigateToGitLabWorkItemsPage(GitLabWorkItemsPageMode.MergeRequests);
         }
     }
 }

--- a/src/GitLab.TeamFoundation.14/Settings.cs
+++ b/src/GitLab.TeamFoundation.14/Settings.cs
@@ -16,6 +16,10 @@ namespace GitLab.TeamFoundation
         public const string PublishSectionId = "3B5CEDDD-0AD3-469B-988A-9F8B71A5ACCF";
         public const int PublishSectionPriority = 10;
 
+        public const string GitLabWorkItemsPageId = "C4B0E9CC-3F0F-47DB-9DDE-3EF1A5936E7C";
+        public const string GitLabSettingsSectionId = "9959F3E9-4309-4C72-B3B7-7C22F559CA59";
+        public const int GitLabSettingsSectionPriority = 50;
+
         public const string IssuesNavigationItemId = "31cdaebc-bf79-424e-963a-5ee5eb72dfed";
         public const int Issues = TeamExplorerNavigationItemPriority.GitCommits - 1;
 

--- a/src/GitLab.TeamFoundation.14/ViewModels/GitLabSettingsViewModel.cs
+++ b/src/GitLab.TeamFoundation.14/ViewModels/GitLabSettingsViewModel.cs
@@ -1,0 +1,83 @@
+using GitLab.VisualStudio.Shared;
+using GitLab.VisualStudio.Shared.Helpers;
+using GitLab.VisualStudio.Shared.Helpers.Commands;
+using GitLab.VisualStudio.Shared.Models;
+using System;
+using System.Windows.Input;
+
+namespace GitLab.TeamFoundation.ViewModels
+{
+    public class GitLabSettingsViewModel : Bindable
+    {
+        private readonly IStorage _storage;
+        private string _defaultBranch;
+        private string _issuesProjectPath;
+        private string _mergeRequestsProjectPath;
+        private string _statusMessage;
+
+        public GitLabSettingsViewModel(IStorage storage)
+        {
+            _storage = storage;
+            SaveCommand = new DelegateCommand(SaveSettings);
+
+            var settings = _storage.AppSettings ?? new AppSettings();
+            DefaultBranch = NormalizeDefaultBranch(settings.DefaultBranch);
+            IssuesProjectPath = settings.IssuesProjectPath;
+            MergeRequestsProjectPath = settings.MergeRequestsProjectPath;
+        }
+
+        public ICommand SaveCommand { get; private set; }
+
+        public string DefaultBranch
+        {
+            get { return _defaultBranch; }
+            set { SetProperty(ref _defaultBranch, value); }
+        }
+
+        public string IssuesProjectPath
+        {
+            get { return _issuesProjectPath; }
+            set { SetProperty(ref _issuesProjectPath, value); }
+        }
+
+        public string MergeRequestsProjectPath
+        {
+            get { return _mergeRequestsProjectPath; }
+            set { SetProperty(ref _mergeRequestsProjectPath, value); }
+        }
+
+        public string StatusMessage
+        {
+            get { return _statusMessage; }
+            set { SetProperty(ref _statusMessage, value); }
+        }
+
+        private void SaveSettings()
+        {
+            try
+            {
+                var settings = _storage.AppSettings ?? new AppSettings();
+                settings.DefaultBranch = NormalizeDefaultBranch(DefaultBranch);
+                settings.IssuesProjectPath = NormalizePath(IssuesProjectPath);
+                settings.MergeRequestsProjectPath = NormalizePath(MergeRequestsProjectPath);
+                _storage.AppSettings = settings;
+                _storage.SaveConfig();
+                StatusMessage = "Saved.";
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = ex.Message;
+            }
+        }
+
+        private static string NormalizeDefaultBranch(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "develop" : value.Trim();
+        }
+
+        private static string NormalizePath(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+    }
+}

--- a/src/GitLab.TeamFoundation.14/ViewModels/GitLabWorkItemsViewModel.cs
+++ b/src/GitLab.TeamFoundation.14/ViewModels/GitLabWorkItemsViewModel.cs
@@ -1,0 +1,236 @@
+using GitLab.TeamFoundation.Home;
+using GitLab.VisualStudio.Shared;
+using GitLab.VisualStudio.Shared.Helpers;
+using GitLab.VisualStudio.Shared.Helpers.Commands;
+using GitLab.VisualStudio.Shared.Models;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Task = System.Threading.Tasks.Task;
+
+namespace GitLab.TeamFoundation.ViewModels
+{
+    public class GitLabWorkItemsViewModel : Bindable
+    {
+        private readonly IStorage _storage;
+        private readonly IWebService _web;
+        private readonly IShellService _shell;
+        private readonly ITeamExplorerServices _tes;
+        private readonly GitLabWorkItemsPageMode _mode;
+
+        private string _projectPath;
+        private string _state;
+        private string _scope;
+        private string _authorUsername;
+        private string _assigneeUsername;
+        private string _labels;
+        private string _search;
+        private string _targetBranch;
+        private string _statusMessage;
+        private bool _isBusy;
+        private GitLabWorkItem _selectedItem;
+
+        public GitLabWorkItemsViewModel(IStorage storage, IWebService web, IShellService shell, ITeamExplorerServices tes, GitLabWorkItemsPageMode mode)
+        {
+            _storage = storage;
+            _web = web;
+            _shell = shell;
+            _tes = tes;
+            _mode = mode;
+
+            Items = new ObservableCollection<GitLabWorkItem>();
+            RefreshCommand = new DelegateCommand(Refresh);
+            OpenCommand = new DelegateCommand(OpenSelected);
+
+            var settings = _storage.AppSettings ?? new AppSettings();
+            DefaultBranch = NormalizeDefaultBranch(settings.DefaultBranch);
+            State = "opened";
+            Scope = "all";
+            TargetBranch = mode == GitLabWorkItemsPageMode.MergeRequests ? DefaultBranch : string.Empty;
+            ProjectPath = GetConfiguredProjectPath(settings);
+
+            Refresh();
+        }
+
+        public ObservableCollection<GitLabWorkItem> Items { get; private set; }
+
+        public ICommand RefreshCommand { get; private set; }
+
+        public ICommand OpenCommand { get; private set; }
+
+        public string Title
+        {
+            get { return IsMergeRequests ? Strings.Items_MergeRequests : Strings.Items_Issues; }
+        }
+
+        public bool IsMergeRequests
+        {
+            get { return _mode == GitLabWorkItemsPageMode.MergeRequests; }
+        }
+
+        public string DefaultBranch { get; private set; }
+
+        public string ProjectPath
+        {
+            get { return _projectPath; }
+            set { SetProperty(ref _projectPath, value); }
+        }
+
+        public string State
+        {
+            get { return _state; }
+            set { SetProperty(ref _state, value); }
+        }
+
+        public string Scope
+        {
+            get { return _scope; }
+            set { SetProperty(ref _scope, value); }
+        }
+
+        public string AuthorUsername
+        {
+            get { return _authorUsername; }
+            set { SetProperty(ref _authorUsername, value); }
+        }
+
+        public string AssigneeUsername
+        {
+            get { return _assigneeUsername; }
+            set { SetProperty(ref _assigneeUsername, value); }
+        }
+
+        public string Labels
+        {
+            get { return _labels; }
+            set { SetProperty(ref _labels, value); }
+        }
+
+        public string Search
+        {
+            get { return _search; }
+            set { SetProperty(ref _search, value); }
+        }
+
+        public string TargetBranch
+        {
+            get { return _targetBranch; }
+            set { SetProperty(ref _targetBranch, value); }
+        }
+
+        public string StatusMessage
+        {
+            get { return _statusMessage; }
+            set { SetProperty(ref _statusMessage, value); }
+        }
+
+        public bool IsBusy
+        {
+            get { return _isBusy; }
+            set { SetProperty(ref _isBusy, value); }
+        }
+
+        public GitLabWorkItem SelectedItem
+        {
+            get { return _selectedItem; }
+            set { SetProperty(ref _selectedItem, value); }
+        }
+
+        public void Refresh()
+        {
+            if (IsBusy)
+            {
+                return;
+            }
+
+            var query = BuildQuery();
+            var mode = _mode;
+            IsBusy = true;
+            StatusMessage = "Loading...";
+
+            Task.Run(() =>
+            {
+                return mode == GitLabWorkItemsPageMode.MergeRequests
+                    ? _web.GetMergeRequests(query)
+                    : _web.GetIssues(query);
+            }).ContinueWith(async t =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                IsBusy = false;
+                Items.Clear();
+
+                if (t.IsFaulted)
+                {
+                    var ex = t.Exception != null ? t.Exception.GetBaseException() : null;
+                    StatusMessage = ex != null ? ex.Message : "Failed to load GitLab items.";
+                    _tes.ShowError(StatusMessage);
+                    return;
+                }
+
+                foreach (var item in t.Result.OrderByDescending(x => x.UpdatedAt ?? x.CreatedAt ?? DateTime.MinValue))
+                {
+                    Items.Add(item);
+                }
+
+                StatusMessage = Items.Count + " item(s)";
+            }, TaskScheduler.Default).Forget();
+        }
+
+        private GitLabWorkItemQuery BuildQuery()
+        {
+            return new GitLabWorkItemQuery
+            {
+                ProjectPath = ProjectPath,
+                State = State,
+                Scope = Scope,
+                AuthorUsername = AuthorUsername,
+                AssigneeUsername = AssigneeUsername,
+                Labels = Labels,
+                Search = Search,
+                TargetBranch = IsMergeRequests ? TargetBranch : null
+            };
+        }
+
+        private void OpenSelected()
+        {
+            if (SelectedItem != null && !string.IsNullOrWhiteSpace(SelectedItem.WebUrl))
+            {
+                _shell.OpenUrl(SelectedItem.WebUrl);
+            }
+        }
+
+        private string GetConfiguredProjectPath(AppSettings settings)
+        {
+            var configuredPath = IsMergeRequests ? settings.MergeRequestsProjectPath : settings.IssuesProjectPath;
+            if (!string.IsNullOrWhiteSpace(configuredPath))
+            {
+                return configuredPath;
+            }
+
+            var project = _tes.Project;
+            if (project != null)
+            {
+                if (!string.IsNullOrWhiteSpace(project.PathWithNamespace))
+                {
+                    return project.PathWithNamespace;
+                }
+
+                if (!string.IsNullOrWhiteSpace(project.Namespace) && !string.IsNullOrWhiteSpace(project.Path))
+                {
+                    return project.Namespace + "/" + project.Path;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static string NormalizeDefaultBranch(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "develop" : value.Trim();
+        }
+    }
+}

--- a/src/GitLab.TeamFoundation.14/Views/GitLabSettingsView.cs
+++ b/src/GitLab.TeamFoundation.14/Views/GitLabSettingsView.cs
@@ -1,0 +1,70 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace GitLab.TeamFoundation.Views
+{
+    public class GitLabSettingsView : UserControl
+    {
+        public GitLabSettingsView()
+        {
+            Content = CreateContent();
+        }
+
+        private UIElement CreateContent()
+        {
+            var panel = new StackPanel
+            {
+                Margin = new Thickness(8)
+            };
+
+            panel.Children.Add(CreateTextBox("Default branch", "DefaultBranch"));
+            panel.Children.Add(CreateTextBox("Issues project", "IssuesProjectPath"));
+            panel.Children.Add(CreateTextBox("Merge requests project", "MergeRequestsProjectPath"));
+
+            var saveButton = new Button
+            {
+                Content = "Save",
+                HorizontalAlignment = HorizontalAlignment.Left,
+                MinWidth = 72,
+                Margin = new Thickness(0, 4, 0, 8),
+                Padding = new Thickness(8, 2, 8, 2)
+            };
+            saveButton.SetBinding(Button.CommandProperty, new Binding("SaveCommand"));
+            panel.Children.Add(saveButton);
+
+            var status = new TextBlock();
+            status.SetBinding(TextBlock.TextProperty, new Binding("StatusMessage"));
+            panel.Children.Add(status);
+
+            return panel;
+        }
+
+        private static FrameworkElement CreateTextBox(string label, string path)
+        {
+            var panel = new StackPanel
+            {
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+
+            panel.Children.Add(new TextBlock
+            {
+                Text = label,
+                Margin = new Thickness(0, 0, 0, 2)
+            });
+
+            var textBox = new TextBox
+            {
+                MinWidth = 220
+            };
+            textBox.SetBinding(TextBox.TextProperty, new Binding(path)
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+            panel.Children.Add(textBox);
+
+            return panel;
+        }
+    }
+}

--- a/src/GitLab.TeamFoundation.14/Views/GitLabWorkItemsView.cs
+++ b/src/GitLab.TeamFoundation.14/Views/GitLabWorkItemsView.cs
@@ -1,0 +1,182 @@
+using GitLab.TeamFoundation.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+
+namespace GitLab.TeamFoundation.Views
+{
+    public class GitLabWorkItemsView : UserControl
+    {
+        private readonly bool _showTargetBranch;
+
+        public GitLabWorkItemsView(bool showTargetBranch)
+        {
+            _showTargetBranch = showTargetBranch;
+            Content = CreateContent();
+        }
+
+        private UIElement CreateContent()
+        {
+            var root = new DockPanel
+            {
+                LastChildFill = true,
+                Margin = new Thickness(8)
+            };
+
+            var filters = new WrapPanel
+            {
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            DockPanel.SetDock(filters, Dock.Top);
+
+            filters.Children.Add(CreateTextBox("Project", "ProjectPath", 180));
+            filters.Children.Add(CreateComboBox("State", "State", _showTargetBranch
+                ? new[] { "opened", "merged", "closed", "locked", "all" }
+                : new[] { "opened", "closed", "all" }, 90));
+            filters.Children.Add(CreateComboBox("Scope", "Scope", new[] { "all", "created_by_me", "assigned_to_me" }, 120));
+            filters.Children.Add(CreateTextBox("Author", "AuthorUsername", 105));
+            filters.Children.Add(CreateTextBox("Assignee", "AssigneeUsername", 105));
+            filters.Children.Add(CreateTextBox("Labels", "Labels", 120));
+            filters.Children.Add(CreateTextBox("Search", "Search", 120));
+            if (_showTargetBranch)
+            {
+                filters.Children.Add(CreateTextBox("Target", "TargetBranch", 100));
+            }
+
+            var refreshButton = new Button
+            {
+                Content = "Refresh",
+                MinWidth = 72,
+                Margin = new Thickness(4, 0, 4, 6),
+                Padding = new Thickness(8, 2, 8, 2)
+            };
+            refreshButton.SetBinding(Button.CommandProperty, new Binding("RefreshCommand"));
+            filters.Children.Add(refreshButton);
+
+            var openButton = new Button
+            {
+                Content = "Open",
+                MinWidth = 60,
+                Margin = new Thickness(4, 0, 4, 6),
+                Padding = new Thickness(8, 2, 8, 2)
+            };
+            openButton.SetBinding(Button.CommandProperty, new Binding("OpenCommand"));
+            filters.Children.Add(openButton);
+
+            var status = new TextBlock
+            {
+                Margin = new Thickness(0, 0, 0, 6)
+            };
+            status.SetBinding(TextBlock.TextProperty, new Binding("StatusMessage"));
+            DockPanel.SetDock(status, Dock.Top);
+
+            var grid = new DataGrid
+            {
+                AutoGenerateColumns = false,
+                CanUserAddRows = false,
+                CanUserDeleteRows = false,
+                IsReadOnly = true,
+                SelectionMode = DataGridSelectionMode.Single,
+                MinHeight = 280
+            };
+            grid.SetBinding(DataGrid.ItemsSourceProperty, new Binding("Items"));
+            grid.SetBinding(DataGrid.SelectedItemProperty, new Binding("SelectedItem") { Mode = BindingMode.TwoWay });
+            grid.MouseDoubleClick += OnGridMouseDoubleClick;
+
+            grid.Columns.Add(CreateColumn("ID", "Reference", 58));
+            grid.Columns.Add(CreateColumn("Title", "Title", 260));
+            grid.Columns.Add(CreateColumn("State", "State", 76));
+            grid.Columns.Add(CreateColumn("Author", "Author", 90));
+            grid.Columns.Add(CreateColumn("Assignees", "Assignees", 120));
+            grid.Columns.Add(CreateColumn("Labels", "Labels", 180));
+            if (_showTargetBranch)
+            {
+                grid.Columns.Add(CreateColumn("Source", "SourceBranch", 120));
+                grid.Columns.Add(CreateColumn("Target", "TargetBranch", 120));
+            }
+            grid.Columns.Add(CreateColumn("Updated", "UpdatedAt", 120, "g"));
+
+            root.Children.Add(filters);
+            root.Children.Add(status);
+            root.Children.Add(grid);
+            return root;
+        }
+
+        private static FrameworkElement CreateTextBox(string label, string path, double width)
+        {
+            var panel = CreateFieldPanel(label);
+            var textBox = new TextBox
+            {
+                Width = width,
+                Margin = new Thickness(0, 0, 8, 6)
+            };
+            textBox.SetBinding(TextBox.TextProperty, new Binding(path)
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+            panel.Children.Add(textBox);
+            return panel;
+        }
+
+        private static FrameworkElement CreateComboBox(string label, string path, string[] values, double width)
+        {
+            var panel = CreateFieldPanel(label);
+            var comboBox = new ComboBox
+            {
+                Width = width,
+                IsEditable = true,
+                Margin = new Thickness(0, 0, 8, 6)
+            };
+            foreach (var value in values)
+            {
+                comboBox.Items.Add(value);
+            }
+            comboBox.SetBinding(ComboBox.TextProperty, new Binding(path)
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+            panel.Children.Add(comboBox);
+            return panel;
+        }
+
+        private static StackPanel CreateFieldPanel(string label)
+        {
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Margin = new Thickness(0, 0, 4, 0)
+            };
+            panel.Children.Add(new TextBlock { Text = label });
+            return panel;
+        }
+
+        private static DataGridTextColumn CreateColumn(string header, string path, double width, string stringFormat = null)
+        {
+            var binding = new Binding(path);
+            if (!string.IsNullOrWhiteSpace(stringFormat))
+            {
+                binding.StringFormat = stringFormat;
+            }
+
+            return new DataGridTextColumn
+            {
+                Header = header,
+                Binding = binding,
+                Width = width
+            };
+        }
+
+        private void OnGridMouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var vm = DataContext as GitLabWorkItemsViewModel;
+            var command = vm != null ? vm.OpenCommand : null;
+            if (command != null && command.CanExecute(null))
+            {
+                command.Execute(null);
+            }
+        }
+    }
+}

--- a/src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj
+++ b/src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj
@@ -216,7 +216,7 @@
       <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework">
-      <Version>17.14.40265</Version>
+      <Version>17.14.40264</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.14.2142</Version>

--- a/src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj
+++ b/src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj
@@ -18,6 +18,16 @@
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
   </PropertyGroup>
+  <!--
+    Resolve the Team Explorer assemblies from whichever Visual Studio instance is
+    building the project (VS2022 / VS2026 / any edition) instead of a hard-coded
+    "2022\Professional" path. $(VsInstallRoot) is provided by Microsoft.VSSDK.BuildTools;
+    fall back to $(DevEnvDir) (set when building from a Developer Command Prompt / IDE).
+  -->
+  <PropertyGroup>
+    <TeamExplorerDir Condition="'$(VsInstallRoot)' != ''">$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</TeamExplorerDir>
+    <TeamExplorerDir Condition="'$(TeamExplorerDir)' == '' and '$(DevEnvDir)' != ''">$(DevEnvDir)CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</TeamExplorerDir>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -49,37 +59,37 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation.Client">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Client.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Common">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Common.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Controls">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Controls.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Controls.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Git.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Client">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Git.Client.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Contracts">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Git.Contracts.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Controls">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Git.Controls.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Controls.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Provider">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Git.Provider.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Provider.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.VisualStudio.TeamFoundation.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.VisualStudio.TeamFoundation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation.InitializationPackage">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.VisualStudio.TeamFoundation.InitializationPackage.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.VisualStudio.TeamFoundation.InitializationPackage.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation.VersionControl">
-      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.VisualStudio.TeamFoundation.VersionControl.dll</HintPath>
+      <HintPath>$(TeamExplorerDir)Microsoft.VisualStudio.TeamFoundation.VersionControl.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -203,21 +213,21 @@
       <Version>0.26.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.1.32210.191</Version>
+      <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework">
-      <Version>17.1.32210.191</Version>
+      <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4057</Version>
+      <Version>17.14.2142</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.39</Version>
+      <Version>1.1.142</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj
+++ b/src/GitLab.TeamFoundation.17/GitLab.TeamFoundation.17.csproj
@@ -27,6 +27,12 @@
   <PropertyGroup>
     <TeamExplorerDir Condition="'$(VsInstallRoot)' != ''">$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</TeamExplorerDir>
     <TeamExplorerDir Condition="'$(TeamExplorerDir)' == '' and '$(DevEnvDir)' != ''">$(DevEnvDir)CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</TeamExplorerDir>
+    <VsIdeDir Condition="'$(VsInstallRoot)' != ''">$(VsInstallRoot)\Common7\IDE\</VsIdeDir>
+    <VsIdeDir Condition="'$(VsIdeDir)' == '' and '$(DevEnvDir)' != ''">$(DevEnvDir)</VsIdeDir>
+    <VsPublicAssembliesDir Condition="'$(VsIdeDir)' != ''">$(VsIdeDir)PublicAssemblies\</VsPublicAssembliesDir>
+    <VsPrivateAssembliesDir Condition="'$(VsIdeDir)' != ''">$(VsIdeDir)PrivateAssemblies\</VsPrivateAssembliesDir>
+    <VsEditorDir Condition="'$(VsIdeDir)' != ''">$(VsIdeDir)CommonExtensions\Microsoft\Editor\</VsEditorDir>
+    <VsThreadingDir Condition="'$(VsIdeDir)' != ''">$(VsPublicAssembliesDir)Microsoft.VisualStudio.Threading.17.x\</VsThreadingDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,36 +66,47 @@
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation.Client">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Client.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Common">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Common.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Controls">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Controls.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Client">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Client.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Contracts">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Contracts.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Controls">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Controls.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Git.Provider">
       <HintPath>$(TeamExplorerDir)Microsoft.TeamFoundation.Git.Provider.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation">
       <HintPath>$(TeamExplorerDir)Microsoft.VisualStudio.TeamFoundation.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation.InitializationPackage">
       <HintPath>$(TeamExplorerDir)Microsoft.VisualStudio.TeamFoundation.InitializationPackage.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation.VersionControl">
       <HintPath>$(TeamExplorerDir)Microsoft.VisualStudio.TeamFoundation.VersionControl.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -103,8 +120,70 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>$(VsPublicAssembliesDir)System.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(VsIdeDir)' != ''">
+    <Reference Include="Microsoft.VisualStudio.Imaging">
+      <HintPath>$(VsIdeDir)Microsoft.VisualStudio.Imaging.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ImageCatalog">
+      <HintPath>$(VsIdeDir)Microsoft.VisualStudio.ImageCatalog.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Interop">
+      <HintPath>$(VsPublicAssembliesDir)Microsoft.VisualStudio.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop">
+      <HintPath>$(VsPublicAssembliesDir)Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0">
+      <HintPath>$(VsPublicAssembliesDir)Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework">
+      <HintPath>$(VsPublicAssembliesDir)Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop">
+      <HintPath>$(VsPublicAssembliesDir)Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading">
+      <HintPath>$(VsThreadingDir)Microsoft.VisualStudio.Threading.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities">
+      <HintPath>$(VsIdeDir)Microsoft.VisualStudio.Utilities.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation">
+      <HintPath>$(VsPrivateAssembliesDir)Microsoft.VisualStudio.Validation.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility">
+      <HintPath>$(VsEditorDir)Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data">
+      <HintPath>$(VsEditorDir)Microsoft.VisualStudio.Text.Data.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic">
+      <HintPath>$(VsEditorDir)Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI">
+      <HintPath>$(VsEditorDir)Microsoft.VisualStudio.Text.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GitLab.TeamFoundation.14\Colors.cs">
@@ -127,6 +206,15 @@
     </Compile>
     <Compile Include="..\GitLab.TeamFoundation.14\Home\GitLabNavigationItem.cs">
       <Link>Home\GitLabNavigationItem.cs</Link>
+    </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\Home\GitLabSettingsSection.cs">
+      <Link>Home\GitLabSettingsSection.cs</Link>
+    </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\Home\GitLabWorkItemsPage.cs">
+      <Link>Home\GitLabWorkItemsPage.cs</Link>
+    </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\Home\GitLabWorkItemsPageMode.cs">
+      <Link>Home\GitLabWorkItemsPageMode.cs</Link>
     </Compile>
     <Compile Include="..\GitLab.TeamFoundation.14\Home\GraphNavigationItem.cs">
       <Link>Home\GraphNavigationItem.cs</Link>
@@ -161,6 +249,12 @@
     <Compile Include="..\GitLab.TeamFoundation.14\ViewModels\ConnectSectionViewModel.cs">
       <Link>ViewModels\ConnectSectionViewModel.cs</Link>
     </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\ViewModels\GitLabSettingsViewModel.cs">
+      <Link>ViewModels\GitLabSettingsViewModel.cs</Link>
+    </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\ViewModels\GitLabWorkItemsViewModel.cs">
+      <Link>ViewModels\GitLabWorkItemsViewModel.cs</Link>
+    </Compile>
     <Compile Include="..\GitLab.TeamFoundation.14\ViewModels\PublishSectionViewModel.cs">
       <Link>ViewModels\PublishSectionViewModel.cs</Link>
     </Compile>
@@ -171,6 +265,12 @@
     <Compile Include="..\GitLab.TeamFoundation.14\Views\PublishSectionView.xaml.cs">
       <Link>Views\PublishSectionView.xaml.cs</Link>
       <DependentUpon>PublishSectionView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\Views\GitLabSettingsView.cs">
+      <Link>Views\GitLabSettingsView.cs</Link>
+    </Compile>
+    <Compile Include="..\GitLab.TeamFoundation.14\Views\GitLabWorkItemsView.cs">
+      <Link>Views\GitLabWorkItemsView.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -212,10 +312,10 @@
     <PackageReference Include="LibGit2Sharp">
       <Version>0.26.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Condition="'$(VsInstallRoot)' == '' and '$(DevEnvDir)' == ''">
       <Version>17.14.40265</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework">
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Condition="'$(VsInstallRoot)' == '' and '$(DevEnvDir)' == ''">
       <Version>17.14.40264</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">

--- a/src/GitLab.TeamFoundation.17/app.config
+++ b/src/GitLab.TeamFoundation.17/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Utilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/src/GitLab.VisualStudio.Shared/GitLab.VisualStudio.Shared.csproj
+++ b/src/GitLab.VisualStudio.Shared/GitLab.VisualStudio.Shared.csproj
@@ -180,18 +180,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.1.32210.191</Version>
+      <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4057</Version>
+      <Version>17.14.2142</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.39</Version>
+      <Version>1.1.142</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NGitLab.Plus">
       <Version>2.0.44</Version>

--- a/src/GitLab.VisualStudio.Shared/GitLab.VisualStudio.Shared.csproj
+++ b/src/GitLab.VisualStudio.Shared/GitLab.VisualStudio.Shared.csproj
@@ -102,6 +102,8 @@
     <Compile Include="IShellService.cs" />
     <Compile Include="IWebService.cs" />
     <Compile Include="Models\AppSettings.cs" />
+    <Compile Include="Models\GitLabWorkItem.cs" />
+    <Compile Include="Models\GitLabWorkItemQuery.cs" />
     <Compile Include="Models\User.cs" />
     <Compile Include="Models\CreateSnippetResult.cs" />
     <Compile Include="Models\NamespacesPath.cs" />
@@ -181,6 +183,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.14.40265</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.14.2142</Version>

--- a/src/GitLab.VisualStudio.Shared/IWebService.cs
+++ b/src/GitLab.VisualStudio.Shared/IWebService.cs
@@ -45,5 +45,9 @@ namespace GitLab.VisualStudio.Shared
         Project GetProject(string namespacedpath);
 
         IReadOnlyList<NamespacesPath> GetNamespacesPathList();
+
+        IReadOnlyList<GitLabWorkItem> GetIssues(GitLabWorkItemQuery query);
+
+        IReadOnlyList<GitLabWorkItem> GetMergeRequests(GitLabWorkItemQuery query);
     }
 }

--- a/src/GitLab.VisualStudio.Shared/Models/AppSettings.cs
+++ b/src/GitLab.VisualStudio.Shared/Models/AppSettings.cs
@@ -9,5 +9,8 @@ namespace GitLab.VisualStudio.Shared.Models
     public class AppSettings
     {
         public string BasePath { get; set; }
+        public string DefaultBranch { get; set; }
+        public string IssuesProjectPath { get; set; }
+        public string MergeRequestsProjectPath { get; set; }
     }
 }

--- a/src/GitLab.VisualStudio.Shared/Models/GitLabWorkItem.cs
+++ b/src/GitLab.VisualStudio.Shared/Models/GitLabWorkItem.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace GitLab.VisualStudio.Shared.Models
+{
+    public class GitLabWorkItem
+    {
+        public int Id { get; set; }
+        public int Iid { get; set; }
+        public string Title { get; set; }
+        public string State { get; set; }
+        public string Author { get; set; }
+        public string Assignees { get; set; }
+        public string Labels { get; set; }
+        public string WebUrl { get; set; }
+        public string ReferencePrefix { get; set; }
+        public string SourceBranch { get; set; }
+        public string TargetBranch { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+
+        public string Reference
+        {
+            get { return Iid > 0 ? (ReferencePrefix ?? string.Empty) + Iid : string.Empty; }
+        }
+    }
+}

--- a/src/GitLab.VisualStudio.Shared/Models/GitLabWorkItemQuery.cs
+++ b/src/GitLab.VisualStudio.Shared/Models/GitLabWorkItemQuery.cs
@@ -1,0 +1,14 @@
+namespace GitLab.VisualStudio.Shared.Models
+{
+    public class GitLabWorkItemQuery
+    {
+        public string ProjectPath { get; set; }
+        public string State { get; set; }
+        public string Scope { get; set; }
+        public string AuthorUsername { get; set; }
+        public string AssigneeUsername { get; set; }
+        public string Labels { get; set; }
+        public string Search { get; set; }
+        public string TargetBranch { get; set; }
+    }
+}

--- a/src/GitLab.VisualStudio.Shared/Models/Project.cs
+++ b/src/GitLab.VisualStudio.Shared/Models/Project.cs
@@ -18,6 +18,7 @@ namespace GitLab.VisualStudio.Shared.Models
                     Owner = p.Owner,
                     Public = p.Public,
                     Path = p.Path,
+                    PathWithNamespace = p.PathWithNamespace,
                     MergeRequestsEnabled = p.MergeRequestsEnabled,
                     SnippetsEnabled = p.SnippetsEnabled,
                     SshUrl = p.SshUrl,
@@ -39,6 +40,7 @@ namespace GitLab.VisualStudio.Shared.Models
         public string Name { get; set; }
 
         public string Path { get; set; }
+        public string PathWithNamespace { get; set; }
 
         public bool Public { get; set; }
         public string SshUrl { get; set; }

--- a/src/GitLab.VisualStudio.Shared/Strings.resx
+++ b/src/GitLab.VisualStudio.Shared/Strings.resx
@@ -303,7 +303,7 @@
     <value>No Login </value>
   </data>
   <data name="TwoFactorAuthentication" xml:space="preserve">
-    <value>Two Factor Authentication</value>
+    <value>Access Token</value>
   </data>
   <data name="DefaultHost" xml:space="preserve">
     <value>https://gitlab.com/</value>

--- a/src/GitLab.VisualStudio.Shared/Strings.zh-Hans.resx
+++ b/src/GitLab.VisualStudio.Shared/Strings.zh-Hans.resx
@@ -303,7 +303,7 @@
     <value>未登录</value>
   </data>
   <data name="TwoFactorAuthentication" xml:space="preserve">
-    <value>双重认证</value>
+    <value>个人访问令牌</value>
   </data>
   <data name="DefaultHost" xml:space="preserve">
     <value>https://gitclub.cn/</value>

--- a/src/GitLab.VisualStudio.UI/GitLab.VisualStudio.UI.csproj
+++ b/src/GitLab.VisualStudio.UI/GitLab.VisualStudio.UI.csproj
@@ -140,21 +140,21 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EmbedIO">
-      <Version>3.4.3</Version>
+      <Version>3.5.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.1.32210.191</Version>
+      <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4057</Version>
+      <Version>17.14.2142</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.39</Version>
+      <Version>1.1.142</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/GitLab.VisualStudio.UI/GitLab.VisualStudio.UI.csproj
+++ b/src/GitLab.VisualStudio.UI/GitLab.VisualStudio.UI.csproj
@@ -144,6 +144,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.14.40265</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.14.2142</Version>

--- a/src/GitLab.VisualStudio.UI/ViewModels/LoginViewModel.cs
+++ b/src/GitLab.VisualStudio.UI/ViewModels/LoginViewModel.cs
@@ -244,13 +244,6 @@ namespace GitLab.VisualStudio.UI.ViewModels
 
         private void OnLogin()
         {
-            string openurl = $"https://gitlab.com/oauth/authorize?client_id=60e86660b759079b66f429f506166fe1cd8cd5fd350476b06801ea973e46ac93&redirect_uri={REDIRECT_URI}&response_type=code&state=STATE&scope=api&code_challenge=CODE_CHALLENGE&code_challenge_method=S256";
-            var browser = new System.Diagnostics.Process()
-            {
-                StartInfo = new System.Diagnostics.ProcessStartInfo(openurl) { UseShellExecute = true }
-            };
-            browser.Start();
-
             Validate();
             if (HasErrors)
             {
@@ -263,9 +256,9 @@ namespace GitLab.VisualStudio.UI.ViewModels
             Task.Run(() =>
             {
                 bool ok = Enum.TryParse(SelectedApiVersion, true, out ApiVersion apiVersion);
-                if (ok || apiVersion == ApiVersion.AutoDiscovery)
+                if (ok)
                 {
-                    var arys = new ApiVersion[] { ApiVersion.V4_Oauth, ApiVersion.V4, ApiVersion.V3_Oauth, ApiVersion.V3, ApiVersion.V3_1 };
+                    var arys = GetLoginApiVersions(apiVersion, Enable2FA);
                     foreach (var apiv in arys)
                     {
                         try
@@ -277,7 +270,7 @@ namespace GitLab.VisualStudio.UI.ViewModels
                                 BusyContent = null;
                                 successed = true;
                                 user.Host = Host;
-                                _storage.AddHostVersionInfo(Host, apiv);
+                                _storage.AddHostVersionInfo(Host, user.ApiVersion);
                                 break;
                             }
                         }
@@ -304,19 +297,48 @@ namespace GitLab.VisualStudio.UI.ViewModels
             }, TaskScheduler.FromCurrentSynchronizationContext()).Forget();
         }
 
+        private static IEnumerable<ApiVersion> GetLoginApiVersions(ApiVersion apiVersion, bool enable2fa)
+        {
+            if (apiVersion == ApiVersion.AutoDiscovery)
+            {
+                if (enable2fa)
+                {
+                    yield return ApiVersion.V4;
+                    yield break;
+                }
+
+                yield return ApiVersion.V4_Oauth;
+                yield return ApiVersion.V4;
+                yield break;
+            }
+
+            if (enable2fa && apiVersion == ApiVersion.V4_Oauth)
+            {
+                yield return ApiVersion.V4;
+                yield break;
+            }
+
+            yield return apiVersion;
+        }
+
         private void OnForgetPassword()
         {
-            _shell.OpenUrl($"{Host}/users/password/new");
+            _shell.OpenUrl(BuildHostUrl("users/password/new"));
         }
 
         private void OnActiveAccount()
         {
-            _shell.OpenUrl($"{Host}/users/confirmation/new");
+            _shell.OpenUrl(BuildHostUrl("users/confirmation/new"));
         }
 
         private void OnSignup()
         {
-            _shell.OpenUrl($"{Host}users/sign_in#register-pane");
+            _shell.OpenUrl(BuildHostUrl("users/sign_in#register-pane"));
+        }
+
+        private string BuildHostUrl(string relativePath)
+        {
+            return new Uri(new Uri(Host), relativePath).ToString();
         }
     }
 }

--- a/src/GitLab.VisualStudio.UI/Views/LoginView.xaml
+++ b/src/GitLab.VisualStudio.UI/Views/LoginView.xaml
@@ -184,7 +184,7 @@
                     HorizontalAlignment="Right"
                     Command="{Binding SignupCommand}"
                     Content="{x:Static shared:Strings.Login_SignUp}" Margin="0,8,10,106" />
-            <CheckBox IsChecked="{Binding Enable2FA}" x:Name="chk2FA" Content="{x:Static shared:Strings.TwoFactorAuthentication}" HorizontalAlignment="Left" Margin="151,7.8,0,0" Grid.Row="4" VerticalAlignment="Top" Height="16" Width="93" />
+            <CheckBox IsChecked="{Binding Enable2FA}" x:Name="chk2FA" Content="{x:Static shared:Strings.TwoFactorAuthentication}" HorizontalAlignment="Left" Margin="151,7.8,0,0" Grid.Row="4" VerticalAlignment="Top" Height="16" Width="150" />
             <ComboBox x:Name="cbxApiVersion" HorizontalAlignment="Left" Margin="0,3,0,0" Grid.Row="4" VerticalAlignment="Top" Width="146" ItemsSource="{Binding ApiVersions}"
                       DisplayMemberPath="Value"
                       SelectedValuePath="Key"

--- a/src/GitLab.VisualStudio.UI/app.config
+++ b/src/GitLab.VisualStudio.UI/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Utilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/src/GitLab.VisualStudio/GitLab.VisualStudio.csproj
+++ b/src/GitLab.VisualStudio/GitLab.VisualStudio.csproj
@@ -380,6 +380,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.14.40265</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.14.2142</Version>

--- a/src/GitLab.VisualStudio/GitLab.VisualStudio.csproj
+++ b/src/GitLab.VisualStudio/GitLab.VisualStudio.csproj
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.props')" />
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -380,18 +379,18 @@
       <Version>0.26.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.1.32210.191</Version>
+      <Version>17.14.40265</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4057</Version>
+      <Version>17.14.2142</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.39</Version>
+      <Version>1.1.142</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NGitLab.Plus">
       <Version>2.0.44</Version>

--- a/src/GitLab.VisualStudio/GitLabPackage.cs
+++ b/src/GitLab.VisualStudio/GitLabPackage.cs
@@ -239,6 +239,7 @@ namespace GitLab.VisualStudio
         private void MenuItem_BeforeQueryStatus(object sender, EventArgs e)
         {
             var command = (OleMenuCommand)sender;
+            command.Visible = true;
             Debug.WriteLine($"MenuItem_BeforeQueryStatus {command.Text} {command.CommandID.ID} ");
             try
             {
@@ -266,14 +267,15 @@ namespace GitLab.VisualStudio
                             return;
                         }
                         var type = ToGitLabUrlType(command.CommandID.ID);
-                        var targetPath = git.GetGitLabTargetPath(type);
-                        if (type == GitLabUrlType.CurrentBranch && targetPath == "master")
+                        var defaultBranch = GetDefaultBranch();
+                        var targetPath = git.GetGitLabTargetPath(type, defaultBranch);
+                        if (type == GitLabUrlType.CurrentBranch && string.Equals(targetPath, defaultBranch, StringComparison.OrdinalIgnoreCase))
                         {
                             command.Visible = false;
                         }
                         else
                         {
-                            command.Text = git.GetGitLabTargetDescription(type);
+                            command.Text = git.GetGitLabTargetDescription(type, defaultBranch);
                             command.Enabled = true;
                         }
                         break;
@@ -343,7 +345,7 @@ namespace GitLab.VisualStudio
                             }
                             var selectionLineRange = GetSelectionLineRange();
                             var type = ToGitLabUrlType(command.CommandID.ID);
-                            var GitLabUrl = git.BuildGitLabUrl(type, selectionLineRange);
+                            var GitLabUrl = git.BuildGitLabUrl(type, selectionLineRange, GetDefaultBranch());
                             System.Diagnostics.Process.Start(GitLabUrl); // open browser
                         }
                         break;
@@ -432,6 +434,16 @@ namespace GitLab.VisualStudio
             if (commandId == PackageIds.OpenBlame) return GitLabUrlType.Blame;
             if (commandId == PackageIds.OpenCommits) return GitLabUrlType.Commits;
             else return GitLabUrlType.Master;
+        }
+
+        private string GetDefaultBranch()
+        {
+            if (_storage != null && _storage.AppSettings != null && !string.IsNullOrWhiteSpace(_storage.AppSettings.DefaultBranch))
+            {
+                return _storage.AppSettings.DefaultBranch.Trim();
+            }
+
+            return "develop";
         }
 
         public static string GetSolutionDirectory()

--- a/src/GitLab.VisualStudio/Services/GitAnalysis.cs
+++ b/src/GitLab.VisualStudio/Services/GitAnalysis.cs
@@ -48,7 +48,7 @@ namespace GitLab.VisualStudio.Services
         public string RepositoryPath { get; private set; }
         public LibGit2Sharp.Repository Repository { get { return repository; } }
 
-        public string GetGitLabTargetPath(GitLabUrlType urlType)
+        public string GetGitLabTargetPath(GitLabUrlType urlType, string defaultBranch = null)
         {
             switch (urlType)
             {
@@ -63,11 +63,11 @@ namespace GitLab.VisualStudio.Services
 
                 case GitLabUrlType.Master:
                 default:
-                    return "master";
+                    return GetDefaultBranch(defaultBranch);
             }
         }
 
-        public string GetGitLabTargetDescription(GitLabUrlType urlType)
+        public string GetGitLabTargetDescription(GitLabUrlType urlType, string defaultBranch = null)
         {
             switch (urlType)
             {
@@ -88,11 +88,11 @@ namespace GitLab.VisualStudio.Services
 
                 case GitLabUrlType.Master:
                 default:
-                    return "master";
+                    return GetDefaultBranch(defaultBranch);
             }
         }
 
-        public string BuildGitLabUrl(GitLabUrlType urlType, Tuple<int, int> selectionLineRange)
+        public string BuildGitLabUrl(GitLabUrlType urlType, Tuple<int, int> selectionLineRange, string defaultBranch = null)
         {
             // https://GitLab.com/user/repo.git
             string urlRoot = GetRepoUrlRoot();
@@ -101,7 +101,7 @@ namespace GitLab.VisualStudio.Services
             var rootDir = repository.Info.WorkingDirectory;
             var fileIndexPath = targetFullPath.Substring(rootDir.Length).Replace("\\", "/");
 
-            var repositoryTarget = GetGitLabTargetPath(urlType);
+            var repositoryTarget = GetGitLabTargetPath(urlType, defaultBranch);
 
             // line selection
             var fragment = (selectionLineRange != null)
@@ -122,6 +122,11 @@ namespace GitLab.VisualStudio.Services
             var fileUrl = string.Format("{0}/{4}/{1}/{2}{3}", urlRoot.Trim('/'), WebUtility.UrlEncode(repositoryTarget.Trim('/')), fileIndexPath.Trim('/'), fragment, urlshowkind);
 
             return fileUrl;
+        }
+
+        private static string GetDefaultBranch(string defaultBranch)
+        {
+            return string.IsNullOrWhiteSpace(defaultBranch) ? "develop" : defaultBranch.Trim();
         }
 
         public string GetRepoUrlRoot()

--- a/src/GitLab.VisualStudio/Services/Storage.cs
+++ b/src/GitLab.VisualStudio/Services/Storage.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using GitLab.VisualStudio.Helpers;
 
 namespace GitLab.VisualStudio.Services
@@ -16,6 +17,8 @@ namespace GitLab.VisualStudio.Services
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class Storage : IStorage
     {
+        private User _user;
+
         public Storage()
         {
             LoadConfig();
@@ -90,11 +93,12 @@ namespace GitLab.VisualStudio.Services
         public void SaveUser(User user, string password)
         {
             SavePassword(user.Host, user.Username, password);
-            if (user.TwoFactorEnabled)
+            if (string.IsNullOrEmpty(user.PrivateToken))
             {
                 user.PrivateToken = password;
             }
             SaveToken(user.Host, user.Username, user.PrivateToken);
+            _user = user;
             SaveUserToLocal(user);
         }
 
@@ -102,7 +106,7 @@ namespace GitLab.VisualStudio.Services
         {
             try
             {
-                string _path = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $"{new Uri(Host).Host}.gitlab4vs");
+                string _path = GetUserFilePath(user.Host);
                 var fi = new System.IO.FileInfo(_path);
                 if (!fi.Directory.Exists)
                 {
@@ -139,22 +143,49 @@ namespace GitLab.VisualStudio.Services
 
         private User LoadUser()
         {
-            User _user = null;
+            if (_user != null)
+            {
+                return _user;
+            }
+
+            User loadedUser = null;
             try
             {
-                var _path = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $"{new Uri(Host).Host}.gitlab4vs");
+                var _path = GetUserFilePath(Host);
                 if (!System.IO.File.Exists(_path))
                 {
-                    _path = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $"{new Uri(Strings.DefaultHost).Host}.gitlab4vs");
+                    _path = GetUserFilePath(Strings.DefaultHost);
+                }
+                if (!System.IO.File.Exists(_path))
+                {
+                    _path = GetLastUserFilePath();
                 }
 
-                _user = Newtonsoft.Json.JsonConvert.DeserializeObject<User>(System.IO.File.ReadAllText(_path));
-                _user.PrivateToken = GetToken(_user.Host);
+                loadedUser = Newtonsoft.Json.JsonConvert.DeserializeObject<User>(System.IO.File.ReadAllText(_path));
+                loadedUser.PrivateToken = GetToken(loadedUser.Host);
+                _user = loadedUser;
             }
             catch (Exception ex)
             {
             }
-            return _user;
+            return loadedUser;
+        }
+
+        private static string GetUserFilePath(string host)
+        {
+            return System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $"{new Uri(host).Host}.gitlab4vs");
+        }
+
+        private static string GetLastUserFilePath()
+        {
+            var directory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+            var latest = directory.GetFiles("*.gitlab4vs");
+            if (latest.Length == 0)
+            {
+                return null;
+            }
+
+            return latest.OrderByDescending(f => f.LastWriteTimeUtc).First().FullName;
         }
 
         public void Erase()
@@ -214,6 +245,10 @@ namespace GitLab.VisualStudio.Services
                 {
                     var user = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                     AppSettings.BasePath = System.IO.Path.Combine(user, "Source", "Repos");
+                }
+                if (string.IsNullOrEmpty(AppSettings.DefaultBranch))
+                {
+                    AppSettings.DefaultBranch = "develop";
                 }
             }
             catch (Exception ex)

--- a/src/GitLab.VisualStudio/Services/WebService.cs
+++ b/src/GitLab.VisualStudio/Services/WebService.cs
@@ -6,13 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
-using System.Web;
 
 namespace GitLab.VisualStudio.Services
 {
@@ -32,8 +29,7 @@ namespace GitLab.VisualStudio.Services
             {
                 if (lstProject.Count == 0 || Math.Abs(DateTime.Now.Subtract(dts).TotalSeconds) > 30)
                 {
-                    var client = GetClient();
-                    foreach (var item in client.Projects.Membership())
+                    foreach (var item in GetProjects(ProjectListType.Membership))
                     {
                         if (!lstProject.Any(p => p.Id == item.Id))
                         {
@@ -59,6 +55,10 @@ namespace GitLab.VisualStudio.Services
             {
                 throw new UnauthorizedAccessException(Strings.WebService_CreateProject_NotLoginYet);
             }
+            if (IsRestV4(user.ApiVersion))
+            {
+                return GetProjectFromRest(user, namespacedpath);
+            }
             var client = NGitLab.GitLabClient.Connect(user.Host, user.PrivateToken, VsApiVersionToNgitLabversion(user.ApiVersion));
             var pjt = client.Projects.Get(namespacedpath);
             return pjt;
@@ -71,6 +71,10 @@ namespace GitLab.VisualStudio.Services
             if (user == null)
             {
                 throw new UnauthorizedAccessException(Strings.WebService_CreateProject_NotLoginYet);
+            }
+            if (IsRestV4(user.ApiVersion))
+            {
+                return GetProjectsFromRest(user, projectListType);
             }
             var client = NGitLab.GitLabClient.Connect(user.Host, user.PrivateToken, VsApiVersionToNgitLabversion(user.ApiVersion));
             NGitLab.Models.Project[] project = null;
@@ -107,8 +111,38 @@ namespace GitLab.VisualStudio.Services
 
         public User Login(bool enable2fa, string host, string email, string password, ApiVersion apiVersion)
         {
-            NGitLab.GitLabClient client = null;
-            User user = null;
+            User user;
+            if (apiVersion == ApiVersion.V4_Oauth && !enable2fa)
+            {
+                user = LoginV4WithPasswordGrant(host, email, password);
+            }
+            else if (apiVersion == ApiVersion.V4 || apiVersion == ApiVersion.V4_Oauth)
+            {
+                user = LoginV4WithAccessToken(host, password);
+            }
+            else
+            {
+                user = LoginWithLegacyClient(enable2fa, host, email, password, apiVersion);
+            }
+
+            if (user != null && user.Id > 0)
+            {
+                _storage.SaveUser(user, user.PrivateToken);
+                try
+                {
+                    LoadProjects();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex.Message);
+                }
+            }
+            return user;
+        }
+
+        private static User LoginWithLegacyClient(bool enable2fa, string host, string email, string password, ApiVersion apiVersion)
+        {
+            NGitLab.GitLabClient client;
             NGitLab.Impl.ApiVersion _apiVersion = VsApiVersionToNgitLabversion(apiVersion);
             if (enable2fa)
             {
@@ -118,30 +152,284 @@ namespace GitLab.VisualStudio.Services
             {
                 client = NGitLab.GitLabClient.Connect(host, email, password, _apiVersion);
             }
+
+            User user = client.Users.Current();
+            user.PrivateToken = client.ApiToken;
+            user.ApiVersion = apiVersion;
+            user.Host = host;
+            return user;
+        }
+
+        private static User LoginV4WithPasswordGrant(string host, string username, string password)
+        {
+            var token = RequestOAuthPasswordToken(host, username, password);
+            return GetCurrentUser(host, token, ApiVersion.V4_Oauth, TokenAuthenticationMode.Bearer);
+        }
+
+        private static string RequestOAuthPasswordToken(string host, string username, string password)
+        {
+            var json = PostForm(BuildGitLabUrl(host, "oauth/token"), new Dictionary<string, string>
+            {
+                { "grant_type", "password" },
+                { "username", username },
+                { "password", password }
+            });
+
+            var token = json.Value<string>("access_token");
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new InvalidOperationException("OAuth token response does not include access_token.");
+            }
+
+            return token;
+        }
+
+        private static User LoginV4WithAccessToken(string host, string token)
+        {
             try
             {
-                user = client.Users.Current();
-                user.PrivateToken = client.ApiToken;
-                user.ApiVersion = apiVersion;
-                user.Host = host;
-                if (user != null && user.Id > 0)
+                return GetCurrentUser(host, token, ApiVersion.V4, TokenAuthenticationMode.PrivateToken);
+            }
+            catch (Exception privateTokenException)
+            {
+                try
                 {
-                    _storage.SaveUser(user, password);
-                    LoadProjects();
+                    return GetCurrentUser(host, token, ApiVersion.V4_Oauth, TokenAuthenticationMode.Bearer);
+                }
+                catch (Exception bearerException)
+                {
+                    throw new InvalidOperationException(
+                        $"Access token authentication failed. PRIVATE-TOKEN: {privateTokenException.Message}; Bearer: {bearerException.Message}",
+                        bearerException);
+                }
+            }
+        }
+
+        private static User GetCurrentUser(string host, string token, ApiVersion apiVersion, TokenAuthenticationMode authenticationMode)
+        {
+            var json = GetJson(BuildGitLabUrl(host, "api/v4/user"), token, authenticationMode);
+            return new User
+            {
+                Id = json.Value<int>("id"),
+                Username = json.Value<string>("username"),
+                Name = json.Value<string>("name"),
+                Email = json.Value<string>("email") ?? json.Value<string>("public_email"),
+                AvatarUrl = json.Value<string>("avatar_url"),
+                TwoFactorEnabled = json.Value<bool?>("two_factor_enabled") ?? false,
+                PrivateToken = token,
+                ApiVersion = apiVersion,
+                Host = new Uri(host).ToString()
+            };
+        }
+
+        private static bool IsRestV4(ApiVersion apiVersion)
+        {
+            return apiVersion == ApiVersion.V4 || apiVersion == ApiVersion.V4_Oauth;
+        }
+
+        private static IReadOnlyList<Project> GetProjectsFromRest(User user, ProjectListType projectListType)
+        {
+            var query = "simple=true";
+            switch (projectListType)
+            {
+                case ProjectListType.Owned:
+                    query += "&owned=true";
+                    break;
+
+                case ProjectListType.Membership:
+                    query += "&membership=true";
+                    break;
+
+                case ProjectListType.Starred:
+                    query += "&starred=true";
+                    break;
+            }
+
+            return GetPagedArray(user, $"api/v4/projects?{query}")
+                .Select(ToProject)
+                .ToList();
+        }
+
+        private static Project GetProjectFromRest(User user, string namespacedpath)
+        {
+            var id = Uri.EscapeDataString(namespacedpath);
+            return ToProject(GetJson(BuildGitLabUrl(user.Host, $"api/v4/projects/{id}"), user.PrivateToken, GetTokenAuthenticationMode(user)));
+        }
+
+        private static IEnumerable<JObject> GetPagedArray(User user, string relativePath)
+        {
+            var page = 1;
+            while (true)
+            {
+                var separator = relativePath.Contains("?") ? "&" : "?";
+                var url = BuildGitLabUrl(user.Host, $"{relativePath}{separator}per_page=100&page={page}");
+                var request = CreateJsonRequest(url, user.PrivateToken, GetTokenAuthenticationMode(user));
+                var result = ReadJsonArrayResponse(request, out var nextPage);
+                foreach (var item in result.OfType<JObject>())
+                {
+                    yield return item;
+                }
+
+                if (string.IsNullOrEmpty(nextPage) || !int.TryParse(nextPage, out page))
+                {
+                    yield break;
+                }
+            }
+        }
+
+        private static Project ToProject(JObject json)
+        {
+            var namespaceInfo = json["namespace"] as JObject;
+            return new Project
+            {
+                Id = json.Value<int>("id"),
+                Name = json.Value<string>("name"),
+                Path = json.Value<string>("path"),
+                PathWithNamespace = json.Value<string>("path_with_namespace"),
+                Public = string.Equals(json.Value<string>("visibility"), "public", StringComparison.OrdinalIgnoreCase),
+                SshUrl = json.Value<string>("ssh_url_to_repo"),
+                HttpUrl = json.Value<string>("http_url_to_repo"),
+                WebUrl = json.Value<string>("web_url"),
+                Fork = json["forked_from_project"] != null,
+                IssuesEnabled = json.Value<bool?>("issues_enabled") ?? true,
+                MergeRequestsEnabled = json.Value<bool?>("merge_requests_enabled") ?? true,
+                WikiEnabled = json.Value<bool?>("wiki_enabled") ?? false,
+                BuildsEnabled = json.Value<bool?>("jobs_enabled") ?? json.Value<bool?>("builds_enabled") ?? false,
+                SnippetsEnabled = json.Value<bool?>("snippets_enabled") ?? false,
+                Description = json.Value<string>("description"),
+                Namespace = namespaceInfo?.Value<string>("full_path")
+            };
+        }
+
+        private enum TokenAuthenticationMode
+        {
+            PrivateToken,
+            Bearer
+        }
+
+        private static string BuildGitLabUrl(string host, string relativePath)
+        {
+            return new Uri(new Uri(host), relativePath).ToString();
+        }
+
+        private static JObject PostForm(string url, IDictionary<string, string> form)
+        {
+            var body = string.Join("&", form.Select(p => $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value ?? string.Empty)}"));
+            var request = (HttpWebRequest)WebRequest.Create(url);
+            request.Method = "POST";
+            request.Accept = "application/json";
+            request.ContentType = "application/x-www-form-urlencoded";
+            var bytes = Encoding.UTF8.GetBytes(body);
+            request.ContentLength = bytes.Length;
+            using (var requestStream = request.GetRequestStream())
+            {
+                requestStream.Write(bytes, 0, bytes.Length);
+            }
+
+            return ReadJsonResponse(request);
+        }
+
+        private static JObject GetJson(string url, string token, TokenAuthenticationMode authenticationMode)
+        {
+            return ReadJsonResponse(CreateJsonRequest(url, token, authenticationMode));
+        }
+
+        private static HttpWebRequest CreateJsonRequest(string url, string token, TokenAuthenticationMode authenticationMode)
+        {
+            var request = (HttpWebRequest)WebRequest.Create(url);
+            request.Method = "GET";
+            request.Accept = "application/json";
+            if (authenticationMode == TokenAuthenticationMode.Bearer)
+            {
+                request.Headers[HttpRequestHeader.Authorization] = $"Bearer {token}";
+            }
+            else
+            {
+                request.Headers["PRIVATE-TOKEN"] = token;
+            }
+
+            return request;
+        }
+
+        private static TokenAuthenticationMode GetTokenAuthenticationMode(User user)
+        {
+            return user.ApiVersion == ApiVersion.V4_Oauth ? TokenAuthenticationMode.Bearer : TokenAuthenticationMode.PrivateToken;
+        }
+
+        private static JArray ReadJsonArrayResponse(HttpWebRequest request, out string nextPage)
+        {
+            try
+            {
+                using (var response = (HttpWebResponse)request.GetResponse())
+                using (var stream = response.GetResponseStream())
+                using (var reader = new StreamReader(stream))
+                {
+                    nextPage = response.Headers["X-Next-Page"];
+                    return JArray.Parse(reader.ReadToEnd());
                 }
             }
             catch (WebException ex)
             {
-                var res = (HttpWebResponse)ex.Response;
-                var statusCode = (int)res.StatusCode;
+                throw CreateGitLabRequestException(ex);
+            }
+        }
 
-                throw ex;
-            }
-            catch (Exception ex1)
+        private static JObject ReadJsonResponse(HttpWebRequest request)
+        {
+            try
             {
-                throw ex1;
+                using (var response = (HttpWebResponse)request.GetResponse())
+                using (var stream = response.GetResponseStream())
+                using (var reader = new StreamReader(stream))
+                {
+                    return JObject.Parse(reader.ReadToEnd());
+                }
             }
-            return user;
+            catch (WebException ex)
+            {
+                throw CreateGitLabRequestException(ex);
+            }
+        }
+
+        private static Exception CreateGitLabRequestException(WebException ex)
+        {
+            var response = ex.Response as HttpWebResponse;
+            if (response == null)
+            {
+                return ex;
+            }
+
+            string body;
+            using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream))
+            {
+                body = reader.ReadToEnd();
+            }
+
+            var status = $"{(int)response.StatusCode} {response.StatusDescription}";
+            var message = ExtractGitLabErrorMessage(body);
+            return new InvalidOperationException(string.IsNullOrEmpty(message) ? status : $"{status}: {message}", ex);
+        }
+
+        private static string ExtractGitLabErrorMessage(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                var json = JObject.Parse(body);
+                return json.Value<string>("error_description")
+                    ?? json.Value<string>("error")
+                    ?? json.Value<string>("message")
+                    ?? body;
+            }
+            catch (JsonException)
+            {
+                return body;
+            }
         }
 
         private static NGitLab.Impl.ApiVersion VsApiVersionToNgitLabversion(ApiVersion apiVersion)
@@ -174,15 +462,136 @@ namespace GitLab.VisualStudio.Services
             return nplist;
         }
 
+        public IReadOnlyList<GitLabWorkItem> GetIssues(GitLabWorkItemQuery query)
+        {
+            var user = GetStoredUser();
+            var projectPath = ResolveProjectPath(query?.ProjectPath);
+            var parameters = BuildWorkItemQuery(query, false);
+            return GetPagedArray(user, $"api/v4/projects/{Uri.EscapeDataString(projectPath)}/issues?{parameters}")
+                .Select(ToIssue)
+                .ToList();
+        }
+
+        public IReadOnlyList<GitLabWorkItem> GetMergeRequests(GitLabWorkItemQuery query)
+        {
+            var user = GetStoredUser();
+            var projectPath = ResolveProjectPath(query?.ProjectPath);
+            var parameters = BuildWorkItemQuery(query, true);
+            return GetPagedArray(user, $"api/v4/projects/{Uri.EscapeDataString(projectPath)}/merge_requests?{parameters}")
+                .Select(ToMergeRequest)
+                .ToList();
+        }
+
         private NGitLab.GitLabClient GetClient()
+        {
+            var user = GetStoredUser();
+            var client = NGitLab.GitLabClient.Connect(user.Host, user.PrivateToken, VsApiVersionToNgitLabversion(user.ApiVersion));
+            return client;
+        }
+
+        private User GetStoredUser()
         {
             var user = _storage.GetUser();
             if (user == null)
             {
                 throw new UnauthorizedAccessException(Strings.WebService_CreateProject_NotLoginYet);
             }
-            var client = NGitLab.GitLabClient.Connect(user.Host, user.PrivateToken, VsApiVersionToNgitLabversion(user.ApiVersion));
-            return client;
+            return user;
+        }
+
+        private string ResolveProjectPath(string configuredProjectPath)
+        {
+            if (!string.IsNullOrWhiteSpace(configuredProjectPath))
+            {
+                return configuredProjectPath.Trim();
+            }
+
+            var project = GetActiveProject();
+            if (project == null)
+            {
+                throw new InvalidOperationException("GitLab project is not configured and no active GitLab repository was resolved.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(project.PathWithNamespace))
+            {
+                return project.PathWithNamespace;
+            }
+
+            if (!string.IsNullOrWhiteSpace(project.Namespace) && !string.IsNullOrWhiteSpace(project.Path))
+            {
+                return $"{project.Namespace}/{project.Path}";
+            }
+
+            return project.Id.ToString();
+        }
+
+        private static string BuildWorkItemQuery(GitLabWorkItemQuery query, bool includeTargetBranch)
+        {
+            var parameters = new Dictionary<string, string>
+            {
+                { "state", string.IsNullOrWhiteSpace(query?.State) ? "opened" : query.State.Trim() },
+                { "scope", string.IsNullOrWhiteSpace(query?.Scope) ? "all" : query.Scope.Trim() }
+            };
+
+            AddQuery(parameters, "author_username", query?.AuthorUsername);
+            AddQuery(parameters, "assignee_username", query?.AssigneeUsername);
+            AddQuery(parameters, "labels", query?.Labels);
+            AddQuery(parameters, "search", query?.Search);
+            if (includeTargetBranch)
+            {
+                AddQuery(parameters, "target_branch", query?.TargetBranch);
+            }
+
+            return string.Join("&", parameters.Select(p => $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value)}"));
+        }
+
+        private static void AddQuery(IDictionary<string, string> parameters, string key, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                parameters[key] = value.Trim();
+            }
+        }
+
+        private static GitLabWorkItem ToIssue(JObject json)
+        {
+            return ToWorkItem(json, null, null, "#");
+        }
+
+        private static GitLabWorkItem ToMergeRequest(JObject json)
+        {
+            return ToWorkItem(
+                json,
+                json.Value<string>("source_branch"),
+                json.Value<string>("target_branch"),
+                "!");
+        }
+
+        private static GitLabWorkItem ToWorkItem(JObject json, string sourceBranch, string targetBranch, string referencePrefix)
+        {
+            var labels = json["labels"] is JArray labelArray
+                ? string.Join(", ", labelArray.Select(x => x.ToString()))
+                : string.Empty;
+            var assignees = json["assignees"] is JArray assigneeArray
+                ? string.Join(", ", assigneeArray.OfType<JObject>().Select(x => x.Value<string>("username")).Where(x => !string.IsNullOrEmpty(x)))
+                : string.Empty;
+
+            return new GitLabWorkItem
+            {
+                Id = json.Value<int>("id"),
+                Iid = json.Value<int>("iid"),
+                Title = json.Value<string>("title"),
+                State = json.Value<string>("state"),
+                Author = (json["author"] as JObject)?.Value<string>("username"),
+                Assignees = assignees,
+                Labels = labels,
+                WebUrl = json.Value<string>("web_url"),
+                ReferencePrefix = referencePrefix,
+                SourceBranch = sourceBranch,
+                TargetBranch = targetBranch,
+                CreatedAt = json.Value<DateTime?>("created_at"),
+                UpdatedAt = json.Value<DateTime?>("updated_at")
+            };
         }
 
         public CreateProjectResult CreateProject(string name, string description, string VisibilityLevel, int namespaceid)

--- a/src/GitLab.VisualStudio/VSCommandTable.vsct
+++ b/src/GitLab.VisualStudio/VSCommandTable.vsct
@@ -31,6 +31,7 @@
 
       <Button guid="guidOpenOnGitLabCmdSet" id="OpenMaster" priority="0x0100" type="Button">
         <Parent guid="guidOpenOnGitLabCmdSet" id="SubMenuGroup" />
+        <CommandFlag>TextChanges</CommandFlag>
         <Strings>
           <ButtonText>master</ButtonText>
           <CommandName>master</CommandName>

--- a/src/GitLab.VisualStudio/app.config
+++ b/src/GitLab.VisualStudio/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Imaging" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/src/GitLab.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitLab.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="54803a44-49e0-4935-bba4-7d7d91682273" Version="1.3.0" Language="en-US" Publisher="MysticBoy" />
+        <Identity Id="54803a44-49e0-4935-bba4-7d7d91682273" Version="1.3.1" Language="en-US" Publisher="MysticBoy" />
         <DisplayName>GitLab Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">A Visual Studio Extension that brings the GitLab Flow into Visual Studio. Supports Visual Studio 2022 and 2026.</Description>
         <MoreInfo>https://github.com/maikebing/GitLab.VisualStudio</MoreInfo>
@@ -13,7 +13,7 @@
         <Tags>GitLab;git;open source;source control;branch;Pipelines;Registry;Graphs;IssuesMerge Requests;Wiki</Tags>
         <Preview>true</Preview>
     </Metadata>
-    <Installation InstalledByMsi="true">
+    <Installation>
         <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>

--- a/src/GitLab.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitLab.VisualStudio/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="54803a44-49e0-4935-bba4-7d7d91682273" Version="1.2.202" Language="en-US" Publisher="MysticBoy" />
+        <Identity Id="54803a44-49e0-4935-bba4-7d7d91682273" Version="1.3.0" Language="en-US" Publisher="MysticBoy" />
         <DisplayName>GitLab Extension for Visual Studio</DisplayName>
-        <Description xml:space="preserve">A Visual Studio Extension that brings the GitLab Flow into Visual Studio.</Description>
+        <Description xml:space="preserve">A Visual Studio Extension that brings the GitLab Flow into Visual Studio. Supports Visual Studio 2022 and 2026.</Description>
         <MoreInfo>https://github.com/maikebing/GitLab.VisualStudio</MoreInfo>
         <License>LICENSE.txt</License>
         <GettingStartedGuide>https://github.com/maikebing/GitLab.VisualStudio/wiki</GettingStartedGuide>
@@ -14,29 +14,29 @@
         <Preview>true</Preview>
     </Metadata>
     <Installation InstalledByMsi="true">
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>x86</ProductArchitecture>
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-            <ProductArchitecture>x86</ProductArchitecture>
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-            <ProductArchitecture>x86</ProductArchitecture>
+        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.17.0" DisplayName="Visual Studio MPF 17.0" Version="[17.0,18.0)" />
-        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions" DisplayName="Team Explorer" Version="[17.0.31918.5,18.0)" />
+        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.17.0" DisplayName="Visual Studio MPF 17.0" Version="[17.0,19.0)" />
+        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions" DisplayName="Team Explorer" Version="[17.0.31918.5,19.0)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
@@ -45,6 +45,6 @@
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitLab.TeamFoundation.17" Path="|GitLab.TeamFoundation.17|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0.31804.368,18.0)" DisplayName="Visual Studio 核心编辑器" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0.31804.368,19.0)" DisplayName="Visual Studio 核心编辑器" />
     </Prerequisites>
 </PackageManifest>

--- a/src/common/SolutionInfo.cs
+++ b/src/common/SolutionInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("GitLab Extension for Visual Studio")]
 [assembly: ComVisible(false)]
 [assembly: AssemblyCompany("MaikeBing")]
-[assembly: AssemblyCopyright("Copyright ? MaikeBing. 2018")]
+[assembly: AssemblyCopyright("Copyright © MaikeBing. 2018-2026")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -14,6 +14,6 @@ namespace System
 {
     internal static class AssemblyVersionInformation
     {
-        internal const string Version = "1.0.0.0";
+        internal const string Version = "1.3.0.0";
     }
 }


### PR DESCRIPTION
# Upstream Maintenance Request Draft

Hi,

I have been using this extension with newer Visual Studio and private GitLab deployments, and the original extension currently needs several updates for that workflow.

I prepared a maintained fork with the following changes:

- Visual Studio 2026 installation/runtime support.
- VSIX direct-install fix for newer Visual Studio versions.
- Private GitLab sign-in fixes so the configured host is used instead of hardcoded `gitlab.com` URLs.
- GitLab 17.x API v4 OAuth and personal access token validation.
- Removal of API v3 discovery, because modern GitLab no longer supports API v3.
- In-IDE Team Explorer pages for merge request and issue lists, including filters for author, assignee, labels, state, search text, and target branch where applicable.
- Settings for default branch, issue project, and merge request project.
- Default branch context-menu text fix so it displays configured branches such as `develop`.

The fork keeps the MIT license and original attribution. I would like to know whether you would prefer one of these paths:

1. Review and merge the changes into the original repository.
2. Add me as a maintainer so I can help keep the extension current.
3. Transfer maintenance / publishing access if you are no longer maintaining this extension.
4. Keep the original project as-is, in which case I will continue maintaining the fork transparently as a community-maintained version.

Thank you for the original work on this extension.

